### PR TITLE
Look for metadata parameters in the query string and request body.

### DIFF
--- a/src/drafter/routes/drafts_api.clj
+++ b/src/drafter/routes/drafts_api.clj
@@ -40,7 +40,7 @@
                                                           (response/api-response 500 result)
                                                           (response/api-response 201 result)))))))
 
-      (POST "/metadata" [graph :as {params :query-params}]
+      (POST "/metadata" [graph :as {params :params}]
             (let [metadata (api-routes/meta-params params)
                   graphs (if (coll? graph) graph [graph])]
               (if (or (empty? graph) (empty? metadata))
@@ -59,9 +59,9 @@
     (routes
       (POST mount-point {{graph :graph} :params
                          {content-type :content-type} :params
-                         query-params :query-params
+                         params :params
                          {{file-part-content-type :content-type data :tempfile} :file} :params}
-        (let [metadata (api-routes/meta-params query-params)
+        (let [metadata (api-routes/meta-params params)
               data-content-type (or content-type file-part-content-type)]
           ;; when source graph not supplied: append from the file
           (response/when-params [graph data-content-type]

--- a/test/drafter/routes/drafts_api_test.clj
+++ b/test/drafter/routes/drafts_api_test.clj
@@ -50,7 +50,7 @@
   (add-request-file-data request (get-file-request-data path)))
 
 (defn add-request-metadata [request meta-name value]
-  (assoc-in request [:query-params (str "meta-" meta-name)] value))
+  (assoc-in request [:params (str "meta-" meta-name)] value))
 
 (defn add-request-graph [request graph]
   (assoc-in request [:params :graph] graph))


### PR DESCRIPTION
Search in the request body for metadata parameters in the metadata and
update routes in the drafts_api namespace. The 'params' map in the ring
request contains the merged map of query parameters and form parameters
so update the handler functions to search the params map instead of the
query-params map.
