### PR TITLE
Log a warning if drafter kills a query due to a timeout

### DIFF
--- a/src/drafter/operations.clj
+++ b/src/drafter/operations.clj
@@ -134,6 +134,7 @@
   (let [executor-service (Executors/newSingleThreadScheduledExecutor)
         task-future (.scheduleWithFixedDelay executor-service (create-repeating-task-fn f) delay-ms delay-ms TimeUnit/MILLISECONDS)]
     (fn []
+      (timbre/warn "Terminating long running operation as it has exceeded the time out.")
       (future-cancel task-future)
       (.shutdown executor-service))))
 
@@ -229,4 +230,3 @@
   intermediate values the timeout is effectively the operation
   timeout"
   (create-timeouts 60000 240000))
-


### PR DESCRIPTION
@lkitching We should log a warning when we time out a query (we do for updates - just not queries).

I'm assuming this is the right place for the warning?

Might also be worth merging up into stardog if drafter still has timeouts on that branch???
