### PR TITLE
Make mongo user collection name configurable.

### DIFF
--- a/doc/configuring-drafter.org
+++ b/doc/configuring-drafter.org
@@ -58,15 +58,39 @@ By default, endpoints have a query timeout of 30 seconds.
 
 ** Users Database
 
-For the mongo database user backend you can set the environment variables:
+The type of user repository to use is configured by specifying the namespace containing the repository
+definition.
 
-`DRAFTER_USER_DB_NAME=pmd-app2_development`
+*** Mongo
+
+A repository which looks up users in a mongo db instance is defined in the `drafter.user.mongo` namespace:
+
 `DRAFTER_USER_REPO_NS=drafter.user.mongo`
 
-For an in memory database of users specified in a
-`test-users.edn` file you can set:
+The name of the database containing the user collection must be specified:
+
+`DRAFTER_USER_DB_NAME=pmd2_development`
+
+The name of the user collection within the database can also be specified:
+
+`DRAFTER_MONGO_USER_COLLECTION=publish_my_data_users`
+
+If not specified the default collection name of 'users' will be used.
+
+The location of the mongo database can also be specified as a host/port pair:
+`DRAFTER_MONGO_HOST=mongoserver`
+`DRAFTER_MONGO_PORT=8080`
+
+if either the host or port is specified, both are required. If neither is specified the host will default to
+`localhost` and the port to 27017 (the default mongo port).
+
+*** In-memory
+
+To use the in-memory user repository set the namespace to `drafter.user.memory-repository`:
 
 `DRAFTER_USER_REPO_NS=drafter.user.memory-repository`
+
+The memory repository loads its users from a `test-users.edn` file in the working directory so this must exist.
 
 ** User Token Signing Key
 

--- a/resources/drafter-config.edn
+++ b/resources/drafter-config.edn
@@ -14,5 +14,6 @@
  ;;mongo user repository
  :mongo-host #env DRAFTER_MONGO_HOST
  :mongo-port #port #env DRAFTER_MONGO_PORT
+ :mongo-user-collection #or [#env DRAFTER_MONGO_USER_COLLECTION "users"]
  :mongo-db-name #env DRAFTER_USER_DB_NAME
  }

--- a/src/drafter/user/mongo.clj
+++ b/src/drafter/user/mongo.clj
@@ -65,12 +65,17 @@
     user-db-name
     (throw (missing-config-key-exception "User database name required" :mongo-db-name))))
 
+(defn- get-user-collection-name [config]
+  ;;NOTE: user collection has default if not explicitly configured so should always exist
+  (:mongo-user-collection config))
+
 (defn get-repository [config]
   (let [host-config (get-host-config config)
         db-name (get-user-db-name config)
+        collection-name (get-user-collection-name config)
         conn (if (nil? host-config) (mg/connect) (mg/connect host-config))
         db (mg/get-db conn db-name)]
-    (->MongoUserRepository conn db "publish_my_data_users")))
+    (->MongoUserRepository conn db collection-name)))
 
 (defn- user->mongo-user [user]
   (let [[email role digest] ((juxt user/username user/role user/password-digest) user)


### PR DESCRIPTION
Issue #198 - Remove the hard-coding of the mongo user collection name
in user.mongo and make it configurable via the
DRAFTER_USER_MONGO_COLLECTION environment variable. If not specified
the rails default name of 'user' is used.