### PR TITLE
Register custom RDF writers on application initialisation.

### DIFF
--- a/src/drafter/handler.clj
+++ b/src/drafter/handler.clj
@@ -19,6 +19,7 @@
                                              stop-writer!]]
             [drafter.configuration :refer [get-configuration]]
             [drafter.env :as denv]
+            [drafter.rdf.writers :as writers]
             [swirrl-server.async.jobs :refer [restart-id finished-jobs]]
             [noir.util.middleware :refer [app-handler]]
             [ring.middleware
@@ -117,6 +118,7 @@
 
 (defn initialise-services! [config]
   (enc/register-custom-encoders!)
+  (writers/register-custom-rdf-writers!)
 
   (jobs/init-job-settings! config)
   (initialise-write-service!)

--- a/src/drafter/rdf/formats.clj
+++ b/src/drafter/rdf/formats.clj
@@ -1,0 +1,8 @@
+(ns drafter.rdf.formats
+  (:import [org.openrdf.rio RDFFormat]
+           [java.nio.charset Charset]))
+
+(def ^:private ascii (Charset/forName "US-ASCII"))
+(def csv-rdf-format (RDFFormat. "CSV" "text/csv" ascii "csv" false true))
+(def tsv-rdf-format (RDFFormat. "TSV" "text/tab-separated-values" nil "tsv" false true))
+

--- a/src/drafter/rdf/writers.clj
+++ b/src/drafter/rdf/writers.clj
@@ -1,0 +1,58 @@
+(ns drafter.rdf.writers
+  (:require [drafter.rdf.formats :refer [csv-rdf-format tsv-rdf-format]])
+  (:import [java.io OutputStream Writer]
+           [org.openrdf.query.impl MapBindingSet]
+           [org.openrdf.query.resultio.text.csv SPARQLResultsCSVWriter]
+           [org.openrdf.query.resultio.text.tsv SPARQLResultsTSVWriter]
+           [org.openrdf.rio RDFWriter RDFWriterFactory RDFWriterRegistry]))
+
+(defn- query-result-writer->rdf-writer [rdf-format result-writer]
+  (reify RDFWriter
+    (getRDFFormat [this] rdf-format)
+    (getWriterConfig [this] (.getWriterConfig result-writer))
+    (setWriterConfig [this config] (.setWriterConfig result-writer config))
+    (getSupportedSettings [this] (.getSupportedSettings result-writer))
+    (startRDF [this]
+      (.startQueryResult result-writer '("s" "p" "o")))
+    (endRDF [this]
+      (.endQueryResult result-writer))
+    (handleNamespace [this prefix uri]
+      ;; No op
+      )
+    (handleStatement [this statement]
+      (let [s (.getSubject statement)
+            p (.getPredicate statement)
+            o (.getObject statement)
+            bs (doto (MapBindingSet.)
+                 (.addBinding "s" s)
+                 (.addBinding "p" p)
+                 (.addBinding "o" o))]
+        (.handleSolution result-writer bs)))
+    (handleComment [this comment]
+      ;; No op
+      )))
+
+(defn- create-rdf-writer-factory [rdf-format writer-fn]
+  (reify RDFWriterFactory
+    (getRDFFormat [this] rdf-format)
+    (^RDFWriter getWriter [this ^OutputStream os]
+      (query-result-writer->rdf-writer rdf-format (writer-fn os)))
+    (^RDFWriter getWriter [this ^Writer w]
+      (throw (RuntimeException. "Not supported - use OutputStream overload")))))
+
+(defn- get-rdf-writer-registry []
+  (RDFWriterRegistry/getInstance))
+
+(defn- register-rdf-writer-factory [writer-factory]
+  (.add (get-rdf-writer-registry) writer-factory))
+
+(defn- create-csv-result-writer [output-stream]
+  (SPARQLResultsCSVWriter. output-stream))
+
+(defn- create-tsv-result-writer [output-stream]
+  (SPARQLResultsTSVWriter. output-stream))
+
+(defn register-custom-rdf-writers! []
+  (register-rdf-writer-factory (create-rdf-writer-factory csv-rdf-format create-csv-result-writer))
+  (register-rdf-writer-factory (create-rdf-writer-factory tsv-rdf-format create-tsv-result-writer)))
+


### PR DESCRIPTION
Issue #132 - register custom RDF writers with a function called during
initialisation rather than at read time. Move the custom writer
definitions into the new rdf.writers namespace and the CSV and TSV
formats to rdf.formats.