### PR TITLE
Support SPARQL queries in POST request bodies.

### DIFF
--- a/doc/drafter.yml
+++ b/doc/drafter.yml
@@ -613,7 +613,7 @@ paths:
         Query the live data via the SPARQL query langauge and protocol.
         Please consult the SPARQL query protocol specification http://www.w3.org/TR/sparql11-protocol/ for a description of this endpoint.
       consumes:
-        - application/sparql-query
+        - application/x-www-form-urlencoded
       produces:
         - application/n-triples
         - application/rdf+xml

--- a/src/drafter/rdf/sparql_protocol.clj
+++ b/src/drafter/rdf/sparql_protocol.clj
@@ -3,7 +3,7 @@
             [compojure.core :refer [make-route]]
             [drafter
              [channels :refer :all]
-             [middleware :refer [allowed-methods-handler require-params sparql-negotiation-handler sparql-prepare-query-handler sparql-timeout-handler]]
+             [middleware :refer [allowed-methods-handler sparql-negotiation-handler sparql-prepare-query-handler sparql-timeout-handler sparql-query-parser-handler]]
              [timeouts :as timeouts]]
             [drafter.rdf.sesame
              :refer
@@ -79,8 +79,7 @@
        (sparql-timeout-handler query-timeout-fn)
        (sparql-negotiation-handler)
        (prepare-handler)
-       (require-params #{:query})
-       (allowed-methods-handler #{:get :post})))
+       (sparql-query-parser-handler)))
 
 (defn sparql-protocol-handler [executor query-timeout-fn]
   (build-sparql-protocol-handler #(sparql-prepare-query-handler executor %) sparql-execution-handler query-timeout-fn))

--- a/test/drafter/middleware_test.clj
+++ b/test/drafter/middleware_test.clj
@@ -15,7 +15,8 @@
              [repository :as repo]]
             [ring.util.response :refer [response]])
   (:import clojure.lang.ExceptionInfo
-           java.io.File))
+           java.io.File
+           (java.io ByteArrayInputStream)))
 
 (defn- add-auth-header [m username password]
   (let [credentials (str->base64 (str username ":" password))]
@@ -204,15 +205,87 @@
           result (handler {:uri "/test" :request-method :post :body body-stream})]
       (is (= body-text result)))))
 
+(deftest sparql-query-parser-handler-test
+  (let [handler (sparql-query-parser-handler identity)
+        query-string "SELECT * WHERE { ?s ?p ?o }"]
+    (testing "Valid GET request"
+      (let [req {:request-method :get :query-params {:query query-string}}
+            inner-req (handler req)]
+        (is (= query-string (get-in inner-req [:sparql :query-string])))))
+
+    (testing "Invalid GET request with missing query parameter"
+      (let [resp (handler {:request-method :get :query-params {}})]
+        (tc/assert-is-unprocessable-response resp)))
+
+    (testing "Invalid GET request with multiple 'query' query parameters"
+      (let [req {:request-method :get
+                 :query-params {:query [query-string "CONSTRUCT { ?s ?p ?o } WHERE { ?s ?p ?o }"]}}
+            resp (handler req)]
+        (tc/assert-is-unprocessable-response resp)))
+
+    (testing "Valid form POST request"
+      (let [req {:request-method :post
+                 :headers {"content-type" "application/x-www-form-urlencoded"}
+                 :form-params {"query" query-string}}
+            inner-req (handler req)]
+        (is (= query-string (get-in inner-req [:sparql :query-string])))))
+
+    (testing "Invalid form POST request with missing query form parameter"
+      (let [req {:request-method :post
+                 :headers {"content-type" "application/x-www-form-urlencoded"}
+                 :form-params {}}
+            resp (handler req)]
+        (tc/assert-is-unprocessable-response resp)))
+
+    (testing "Invalid form POST request with multiple query form parameters"
+      (let [req {:request-method :post
+                 :headers {"content-type" "application/x-www-form-urlencoded"}
+                 :form-params {"query" [query-string "CONSTRUCT { ?s ?p ?o } WHERE { ?s ?p ?o }"]}}
+            resp (handler req)]
+        (tc/assert-is-unprocessable-response resp)))
+
+    (testing "Valid body POST request"
+      (let [req {:request-method :post
+                 :headers {"content-type" "application/sparql-query"}
+                 :body query-string}
+            inner-req (handler req)]
+        (is (= query-string (get-in inner-req [:sparql :query-string])))))
+
+    (testing "Invalid body POST request missing body"
+      (let [req {:request-method :post
+                 :headers {"content-type" "application/sparql-query"}
+                 :body nil}
+            resp (handler req)]
+        (tc/assert-is-unprocessable-response resp)))
+
+    (testing "Invalid body POST request non-string body"
+      (let [req {:request-method :post
+                 :headers {"content-type" "application/sparql-query"}
+                 :body (ByteArrayInputStream. (byte-array [1 2 3]))}
+            resp (handler req)]
+        (tc/assert-is-unprocessable-response resp)))
+
+    (testing "POST request with invalid content type"
+      (let [req {:request-method :post
+                 :headers {"content-type" "text/plain"}
+                 :params {:query query-string}}
+            inner-req (handler req)]
+        (is (= query-string (get-in inner-req [:sparql :query-string])))))
+
+    (testing "Invalid request method"
+      (let [req {:request-method :put :body query-string}
+            resp (handler req)]
+        (tc/assert-is-method-not-allowed-response resp)))))
+
 (deftest sparql-prepare-query-handler-test
   (let [r (repo/repo)
         handler (sparql-prepare-query-handler r identity)]
     (testing "Valid query"
-      (let [req (handler {:params {:query "SELECT * WHERE { ?s ?p ?o }"}})]
+      (let [req (handler {:sparql {:query-string "SELECT * WHERE { ?s ?p ?o }"}})]
         (is (some? (get-in req [:sparql :prepared-query])))))
 
     (testing "Malformed SPARQL query"
-      (let [response (handler {:params {:query "NOT A SPARQL QUERY"}})]
+      (let [response (handler {:sparql {:query-string "NOT A SPARQL QUERY"}})]
         (tc/assert-is-bad-request-response response)))))
 
 (defn- prepare-query-str [query-str]

--- a/test/drafter/rdf/sparql_protocol_test.clj
+++ b/test/drafter/rdf/sparql_protocol_test.clj
@@ -21,7 +21,7 @@
       (let [{:keys [status headers body]
              :as result} (end-point {:request-method :get
                                      :uri "/live/sparql"
-                                     :params {:query "SELECT * WHERE { ?s ?p ?o } LIMIT 10"}
+                                     :query-params {:query "SELECT * WHERE { ?s ?p ?o } LIMIT 10"}
                                      :headers {"accept" "text/csv"}})]
 
         (is (= 200 status))
@@ -41,7 +41,7 @@
       (let [{:keys [status headers body]
              :as result} (end-point {:request-method :get
                                      :uri "/live/sparql"
-                                     :params {:query "CONSTRUCT { ?s ?p ?o } WHERE { ?s ?p ?o } LIMIT 10"}
+                                     :query-params {:query "CONSTRUCT { ?s ?p ?o } WHERE { ?s ?p ?o } LIMIT 10"}
                                      :headers {"accept" "text/csv;q=0.7,text/unknown,application/n-triples;q=0.9"}})]
 
         (is (= 200 status))
@@ -59,7 +59,7 @@
       (let [{:keys [status headers body]
              :as result} (end-point {:request-method :get
                                      :uri "/live/sparql"
-                                     :params {:query "SELECT * WHERE { ?s ?p ?o } LIMIT 10"}
+                                     :query-params {:query "SELECT * WHERE { ?s ?p ?o } LIMIT 10"}
                                      :headers {"accept" "text/csv,application/sparql-results+json;q=0.9,*/*;q=0.8"}})]
 
         (is (= 200 status))
@@ -75,12 +75,11 @@
   (let [end-point (sparql-end-point "/live/sparql" *test-backend*)]
     (testing "Boolean SPARQL query with multiple accepted MIME types and qualities"
       (let [{:keys [status headers body]
-             :as result} (end-point {:request-method :get
-                                     :uri "/live/sparql"
-                                     :params {:query "ASK WHERE { ?s ?p ?o }"}
-                                     :headers {"accept" "text/plain,application/sparql-results+json;q=0.1,*/*;q=0.8"
-                                               "Accept-Charset" "utf-8"}})]
-
+             :as resp} (end-point {:request-method :get
+                                   :uri "/live/sparql"
+                                   :query-params {:query "ASK WHERE { ?s ?p ?o }"}
+                                   :headers {"accept" "text/plain,application/sparql-results+json;q=0.1,*/*;q=0.8"
+                                             "Accept-Charset" "utf-8"}})]
         (is (= 200 status))
         (is (= "text/plain; charset=utf-8" (headers "Content-Type")))
 
@@ -93,18 +92,18 @@
       (let [{:keys [status headers body]
              :as result} (end-point {:request-method :get
                                      :uri "/live/sparql"
-                                     :params {:query "SELECT * WHERE { ?s ?p ?o }"}
+                                     :query-params {:query "SELECT * WHERE { ?s ?p ?o }"}
                                      :headers {"accept" "text/html"}})]
 
         (is (= 200 status))
         (is (= "text/plain; charset=utf-8" (headers "Content-Type")))))))
 
-(deftest sparlq-endpoint-invalid-query
+(deftest sparql-endpoint-invalid-query
   (testing "SPARQL endpoint returns client error if SPARQL query invalid"
     (let [endpoint (sparql-end-point "/live/sparql" *test-backend*)
           request {:request-method :get
                    :uri "/live/sparql"
-                   :params {:query "NOT A VALID SPARQL QUERY"}
+                   :query-params {:query "NOT A VALID SPARQL QUERY"}
                    :headers {"accept" "text/plain"}}
           {:keys [status]} (endpoint request)]
       (is (= 400 status)))))
@@ -118,7 +117,7 @@
         endpoint (sparql-end-point "/live/sparql" repo)
         test-request {:uri "/live/sparql"
                       :request-method :get
-                      :params {:query "SELECT * WHERE { ?s ?p ?o }"}
+                      :query-params {:query "SELECT * WHERE { ?s ?p ?o }"}
                       :headers {"accept" "application/sparql-results+json"}}]
     (with-open [server (latched-http-server test-port connection-latch release-latch (get-spo-http-response))]
       (let [blocked-connections (doall (map (fn [i] (future (endpoint test-request))) (range 1 (inc max-connections))))]

--- a/test/drafter/routes/sparql_test.clj
+++ b/test/drafter/routes/sparql_test.clj
@@ -30,14 +30,14 @@
 
 (def default-sparql-query {:request-method :get
                            :uri "/sparql/live"
-                           :params {:query "SELECT * WHERE { ?s ?p ?o }"}
+                           :query-params {:query "SELECT * WHERE { ?s ?p ?o }"}
                            :headers {"accept" "text/csv"}})
 
 (defn- build-query
   ([endpoint-path query] (build-query endpoint-path query))
   ([endpoint-path query graphs]
    (let [query-request (-> default-sparql-query
-                           (assoc-in [:params :query] query)
+                           (assoc-in [:query-params :query] query)
                            (assoc :uri endpoint-path))]
 
      (reduce (fn [req graph]


### PR DESCRIPTION
Issue #181 - Support the application/sparql content type for SPARQL
queries. The query parameter is passed unencoded in the request body in
such requests while GET requests pass parameters in the query string and
application/x-www-form-urlencoded POST requests pass them in the
URL encoded form.

If no content type is provided in POST requests, revert to the existing
behaviour of searching for the query parameter in either the query string
or URL-encoded form.

Update the swagger specification to require that SPARQL queries submitted
in formData should have content type of application/x-www-form-urlencoded.