### PR TITLE
Avoid holding onto generated sequences in batch-partition-by.

### DIFF
--- a/src/drafter/util.clj
+++ b/src/drafter/util.clj
@@ -92,7 +92,7 @@
   take-batches lazily."
   [take-batches partition-fn output-batch-size]
   (lazy-seq
-    (if (seq take-batches)
+    (when (seq take-batches)
       (let [take-batch (first take-batches)
             batch-groups (vals (group-by partition-fn take-batch))
             batches (mapcat (fn [inner]


### PR DESCRIPTION
Issue #279 - mapcat holds onto the head of generated subsequences
if the input sequence contains more than 2 items. The lazy sequence
of input batches created within batch-partition-by is likely to
contain more than two items, so the use of mapcat causes a memory
leak on moderately large input files.

Rewrite batch-partition-by to process the sequence of batches
lazily rather than use mapcat.