### PR TITLE
bump stardog version to 7.0.0

### DIFF
--- a/dependencies.edn
+++ b/dependencies.edn
@@ -1,2 +1,2 @@
-{"stardog" "6.1.2"
+{"stardog" "7.0.0-1.0"
  "server-ssl" "1.0"}


### PR DESCRIPTION
NOTE: this only bumps the pmd4 build of drafter to stardog 7.