### PR TITLE
Pipe jvm opts through capsule to the drafter app

### DIFF
--- a/package/install/drafter-start.sh
+++ b/package/install/drafter-start.sh
@@ -1,9 +1,14 @@
 #! /bin/bash
 
 cd {{omni/install-dir}}
-java -Xmx4g -Dcom.sun.management.jmxremote.ssl=false \
--Dcom.sun.management.jmxremote.authenticate=false \
--Dcom.sun.management.jmxremote.port=3007 \
--Dhttp.maxConnections=60 \
--Dorg.eclipse.jetty.server.Request.maxFormContentSize=41943040 \
--jar {{omni/install-dir}}/drafter.jar drafter-prod-auth0.edn
+
+DRAFTER_JVM_OPTS="-Xmx4g \
+                  -Dcom.sun.management.jmxremote.ssl=false \
+                  -Dcom.sun.management.jmxremote.authenticate=false \
+                  -Dcom.sun.management.jmxremote.port=3007 \
+                  -Dhttp.maxConnections=60 \
+                  -Dorg.eclipse.jetty.server.Request.maxFormContentSize=41943040"
+
+java -Dcapsule.jvm.args="$DRAFTER_JVM_OPTS" \
+     -jar {{omni/install-dir}}/drafter.jar \
+     drafter-prod.edn


### PR DESCRIPTION
Capsule apps use two jvms, one for the Capsule loading stuff, and a
second one for the app (i.e. drafter). The jvm args as they were were
being passed through causing both jvms to open port 3007 for jmx,
which then conflicted and caused drafter to fail to start.

This change passes those same values in through a -Dcapsule.jvm.args
param, which has only the second jvm jmx enabled.

I've also changed drafter-prod-auth0.edn to drafter-prod.edn because
that's what it gets copied to by the install process.