### PR TITLE
Add draft and error metadata to jobs API

### DIFF
--- a/drafter/src/drafter/async/spec.clj
+++ b/drafter/src/drafter/async/spec.clj
@@ -44,18 +44,22 @@
 (s/def :api-job/finish-time (s/nilable date-time-string?))
 (s/def ::draftset-id (s/nilable draftset-id?))
 (s/def ::draft-graph-id (s/nilable uuid-string?))
+(s/def ::metadata (s/nilable (s/with-gen map? (fn [] (gen/elements [{}])))))
 (s/def ::function (s/with-gen fn? (fn [] (gen/elements [identity]))))
-(s/def ::value-p (s/with-gen promise? (fn [] (gen/elements [(promise)]))))
+(s/def ::value-p (s/with-gen promise? (fn [] (let [p (promise)]
+                                              (deliver p {})
+                                              (s/gen #{p})))))
 
 (s/def ::job
   (s/keys :req-un [::id ::user-id ::operation ::status ::priority
                    :internal-job/start-time :internal-job/finish-time
-                   ::draftset-id ::draft-graph-id ::function ::value-p]))
+                   ::draftset-id ::draft-graph-id ::metadata
+                   ::function ::value-p]))
 
 (s/def ::api-job
   (s/keys :req-un [::id ::user-id ::operation ::status ::priority
                    :api-job/start-time :api-job/finish-time]
-          :opt-un [::draftset-id ::draft-graph-id]))
+          :opt-un [::draftset-id ::draft-graph-id ::metadata]))
 
 (s/def :failed-job-result/type #{:error})
 (s/def :success-job-result/type #{:ok})

--- a/drafter/src/drafter/backend/draftset/operations.clj
+++ b/drafter/src/drafter/backend/draftset/operations.clj
@@ -1,33 +1,20 @@
 (ns drafter.backend.draftset.operations
   (:require [clojure.string :as string]
-            [drafter.backend.draftset.draft-management
-             :as
-             mgmt
-             :refer
-             [to-quads with-state-graph]]
-            [drafter.backend.draftset.rewrite-result :refer [rewrite-statement]]
+            [drafter.backend.draftset.draft-management :as mgmt
+             :refer [to-quads with-state-graph]]
             [drafter.draftset :as ds]
             [drafter.rdf.drafter-ontology :refer :all]
-            [drafter.rdf.draftset-management.job-util :as jobs]
-            [drafter.rdf.sesame :refer [read-statements]]
             [drafter.rdf.sparql :as sparql]
             [drafter.user :as user]
             [drafter.util :as util]
-            [drafter.write-scheduler :as writes]
-            [grafter-2.rdf.protocols :as rdf :refer [map->Quad map->Triple context]]
-            [grafter-2.rdf4j.repository :refer [prepare-query]]
-            [grafter-2.rdf4j.formats :as formats]
-            [grafter-2.rdf4j.io :refer [quad->backend-quad rdf-writer]]
-            [grafter-2.rdf4j.repository :as repo]
+            [grafter-2.rdf.protocols :as rdf]
+            [grafter-2.rdf4j.repository :as repo :refer [prepare-query]]
             [grafter.url :as url]
             [grafter.vocabularies.rdf :refer :all])
-  (:import java.io.StringWriter
-           [java.util Date]
-           org.eclipse.rdf4j.model.impl.ContextStatementImpl
-           org.eclipse.rdf4j.model.Resource
-           [org.eclipse.rdf4j.query GraphQuery TupleQueryResultHandler TupleQueryResult]
-           [org.eclipse.rdf4j.rio RDFHandler RDFWriter]
-           org.eclipse.rdf4j.queryrender.RenderUtils))
+  (:import org.eclipse.rdf4j.model.impl.ContextStatementImpl
+           [org.eclipse.rdf4j.query GraphQuery TupleQueryResult TupleQueryResultHandler]
+           org.eclipse.rdf4j.queryrender.RenderUtils
+           org.eclipse.rdf4j.rio.RDFHandler))
 
 (defn- create-draftset-statements [user-uri title description draftset-uri created-date]
   (let [ss [draftset-uri

--- a/drafter/src/drafter/feature/common.clj
+++ b/drafter/src/drafter/feature/common.clj
@@ -11,16 +11,16 @@
     (r/api-response 500 result)
     (ring/response (dsops/get-draftset-info backend draftset-id))))
 
-(defn- as-sync-write-job [user-id operation draftset-id f]
-  (jobutil/make-job user-id operation draftset-id :blocking-write
+(defn- as-sync-write-job [backend user-id operation draftset-id f]
+  (jobutil/make-job backend user-id operation draftset-id :blocking-write
     (fn [job]
       (let [result (f)]
         (ajobs/job-succeeded! job result)))))
 
 (defn run-sync
-  ([user-id operation draftset-id api-call-fn]
+  ([backend user-id operation draftset-id api-call-fn]
    (response/run-sync-job!
-    (as-sync-write-job user-id operation draftset-id api-call-fn)))
-  ([user-id operation draftset-id api-call-fn resp-fn]
+    (as-sync-write-job backend user-id operation draftset-id api-call-fn)))
+  ([backend user-id operation draftset-id api-call-fn resp-fn]
    (response/run-sync-job!
-    (as-sync-write-job user-id operation draftset-id api-call-fn) resp-fn)))
+    (as-sync-write-job backend user-id operation draftset-id api-call-fn) resp-fn)))

--- a/drafter/src/drafter/feature/draftset/changes.clj
+++ b/drafter/src/drafter/feature/draftset/changes.clj
@@ -32,6 +32,7 @@
     true
     (fn [{{:keys [draftset-id graph]} :params :as request}]
       (feat-common/run-sync
+       backend
        (req/user-id request)
        'delete-draftset-changes
        draftset-id

--- a/drafter/src/drafter/feature/draftset/claim.clj
+++ b/drafter/src/drafter/feature/draftset/claim.clj
@@ -25,7 +25,8 @@
   [backend {{:keys [draftset-id]} :params user :identity :as request}]
   (if-let [ds-info (dsops/get-draftset-info backend draftset-id)]
     (if (user/can-claim? user ds-info)
-      (feat-common/run-sync (req/user-id request)
+      (feat-common/run-sync backend
+                            (req/user-id request)
                             'claim-draftset
                             draftset-id
                             #(dsops/claim-draftset! backend draftset-id user)

--- a/drafter/src/drafter/feature/draftset/create.clj
+++ b/drafter/src/drafter/feature/draftset/create.clj
@@ -14,6 +14,7 @@
     (wrap-authenticated
      (fn [{{:keys [display-name description]} :params user :identity :as request}]
        (feat-common/run-sync
+        backend
         (req/user-id request)
         'create-draftset
         nil ; because we're creating the draftset here

--- a/drafter/src/drafter/feature/draftset/set_metadata.clj
+++ b/drafter/src/drafter/feature/draftset/set_metadata.clj
@@ -10,6 +10,7 @@
   (wrap-as-draftset-owner
    (fn [{{:keys [draftset-id] :as params} :params :as request}]
      (feat-common/run-sync
+      backend
       (req/user-id request)
       'set-draftset-metadata
       draftset-id

--- a/drafter/src/drafter/feature/draftset/submit.clj
+++ b/drafter/src/drafter/feature/draftset/submit.clj
@@ -10,6 +10,7 @@
   [backend repo user draftset-id owner]
   (if-let [target-user (user/find-user-by-username repo user)]
     (feat-common/run-sync
+     backend
      (:email owner)
      'submit-draftset-to-user
      draftset-id
@@ -22,6 +23,7 @@
   (let [role-kw (keyword role)]
     (if (user/is-known-role? role-kw)
       (feat-common/run-sync
+       backend
        (:email owner)
        'submit-draftset-to-role
        draftset-id

--- a/drafter/src/drafter/feature/draftset_data/append.clj
+++ b/drafter/src/drafter/feature/draftset_data/append.clj
@@ -72,7 +72,7 @@
   [backend user-id operation draftset-ref quads clock-fn]
   (let [backend (:repo backend)
         ds-id (ds/->draftset-id draftset-ref)]
-    (jobs/make-job user-id operation ds-id :background-write
+    (jobs/make-job backend user-id operation ds-id :background-write
       (fn [job]
         (let [graph-map (ops/get-draftset-graph-mapping backend draftset-ref)
               quad-batches (util/batch-partition-by quads

--- a/drafter/src/drafter/feature/draftset_data/append_by_graph.clj
+++ b/drafter/src/drafter/feature/draftset_data/append_by_graph.clj
@@ -21,7 +21,7 @@
 
 (defn copy-live-graph-into-draftset-job [backend user-id draftset-ref live-graph]
   (let [ds-id (ds/->draftset-id draftset-ref)]
-    (jobs/make-job user-id 'copy-live-graph-into-draftset ds-id :background-write
+    (jobs/make-job backend user-id 'copy-live-graph-into-draftset ds-id :background-write
       (fn [job]
         (let [draft-graph-uri (create-or-empty-draft-graph-for backend draftset-ref live-graph util/get-current-time)]
           (ds-data-common/lock-writes-and-copy-graph backend live-graph draft-graph-uri {:silent true})

--- a/drafter/src/drafter/feature/draftset_data/delete.clj
+++ b/drafter/src/drafter/feature/draftset_data/delete.clj
@@ -77,7 +77,7 @@
   [backend user-id draftset-ref serialised rdf-format clock-fn]
   (let [backend (:repo backend)
         ds-id (ds/->draftset-id draftset-ref)]
-    (jobs/make-job user-id 'delete-quads-from-draftset ds-id :background-write
+    (jobs/make-job backend user-id 'delete-quads-from-draftset ds-id :background-write
       (fn [job]
         (let [quads (read-statements serialised rdf-format)
               graph-mapping (ops/get-draftset-graph-mapping backend draftset-ref)]
@@ -87,7 +87,7 @@
   [backend user-id draftset-ref graph serialised rdf-format clock-fn]
   (let [backend (:repo backend)
         ds-id (ds/->draftset-id draftset-ref)]
-    (jobs/make-job user-id 'delete-triples-from-draftset ds-id :background-write
+    (jobs/make-job backend user-id 'delete-triples-from-draftset ds-id :background-write
       (fn [job]
         (let [triples (read-statements serialised rdf-format)
               quads (map #(util/make-quad-statement % graph) triples)

--- a/drafter/src/drafter/feature/draftset_data/delete_by_graph.clj
+++ b/drafter/src/drafter/feature/draftset_data/delete_by_graph.clj
@@ -23,7 +23,8 @@
      true
      (fn [{{:keys [draftset-id graph silent]} :params :as request}]
        (if (mgmt/is-graph-managed? backend graph)
-         (feat-common/run-sync (req/user-id request)
+         (feat-common/run-sync backend
+                               (req/user-id request)
                                'delete-draftset-graph
                                draftset-id
                                #(dsops/delete-draftset-graph! backend draftset-id graph util/get-current-time)

--- a/drafter/src/drafter/rdf/draftset_management/jobs.clj
+++ b/drafter/src/drafter/rdf/draftset_management/jobs.clj
@@ -19,7 +19,7 @@
 
 (defn delete-draftset-job [backend user-id draftset-ref]
   (let [ds-id (ds/->draftset-id draftset-ref)]
-    (jobs/make-job user-id 'delete-draftset ds-id :background-write
+    (jobs/make-job backend user-id 'delete-draftset ds-id :background-write
       (fn [job]
         (ops/delete-draftset! backend draftset-ref)
         (jobs/job-succeeded! job)))))
@@ -41,7 +41,7 @@
   ;; changed how these will be applied.
 
   (let [ds-id (ds/->draftset-id draftset-ref)]
-    (jobs/make-job user-id 'publish-draftset ds-id :publish-write
+    (jobs/make-job backend user-id 'publish-draftset ds-id :publish-write
       (fn [job]
         (try
           (ops/publish-draftset-graphs! backend draftset-ref clock-fn)

--- a/drafter/test/drafter/async/jobs_test.clj
+++ b/drafter/test/drafter/async/jobs_test.clj
@@ -171,7 +171,8 @@
 
 (tc/deftest-system-with-keys jobs-list-status-test
   [:drafter.routes/jobs-status]
-  [{handler :drafter.routes/jobs-status :as sys} system]
+  [{handler :drafter.routes/jobs-status
+    backend :drafter/backend :as sys} system]
   (let [job (jobs/create-job dummy 'test-job :batch-write (constantly nil))
         path "/v1/status/jobs"]
 
@@ -190,7 +191,7 @@
         (is (= :pending (:status (first body))))))
 
     (testing "Synchronous jobs do not show up in :complete jobs"
-      (let [job (feat-common/run-sync dummy 'test-sync-job nil (constantly nil))]
+      (let [job (feat-common/run-sync backend dummy 'test-sync-job nil (constantly nil))]
         (let [{:keys [body status] :as response}
               (handler (tc/with-identity test-editor (request :get path)))]
           (is (= 200 status))

--- a/drafter/test/drafter/write_scheduler_test.clj
+++ b/drafter/test/drafter/write_scheduler_test.clj
@@ -18,7 +18,7 @@
 (def mock-user-id "dummy@user.com")
 
 (defn mock-job [id type submit-time]
-  (->Job id mock-user-id 'test-job nil type submit-time nil nil nil t (promise)))
+  (->Job id mock-user-id 'test-job nil type submit-time nil nil nil nil t (promise)))
 
 (defn const-job [priority ret]
   (create-job mock-user-id 'test-job priority (fn [job] (job-succeeded! job ret))))


### PR DESCRIPTION
So that we can display the draft name and decent error information in the muttnik jobs screen, this PR adds draft metadata to the job, upon creation (`make-job`). 

Additionally, if the job errors, the jobs API response will be decorated with the `:error`.

Ref: https://github.com/Swirrl/muttnik/issues/198