### PR TITLE
Make `resolve-jobs` wait for all jobs to finish

### DIFF
--- a/drafter-client/src/drafter_client/client.clj
+++ b/drafter-client/src/drafter_client/client.clj
@@ -216,7 +216,7 @@
 (defn resolve-jobs
   "Wait until all of the asynchronous `jobs` have finished"
   [client access-token jobs]
-  (map (fn [job] (resolve-job client access-token job)) jobs))
+  (doall (map (fn [job] (resolve-job client access-token job)) jobs)))
 
 (defn client
   "Create a Drafter client for `drafter-uri` where the (web-)client will pass an


### PR DESCRIPTION
Right now `resolve-jobs` does not actually resolve all the jobs it's given because of the side effect in `resolve-job` that's not executed for the lazily mapped jobs. This makes it do that.