### PR TITLE
Ensure client can append large amounts of data to a Draftset. Fixes #344

### DIFF
--- a/drafter-client/deps.edn
+++ b/drafter-client/deps.edn
@@ -17,7 +17,7 @@
         grafter.db {:mvn/version "0.8.5"}
         com.cemerick/url {:mvn/version "0.1.1"}
         swirrl/auth0 {:git/url "git@github.com:Swirrl/swirrl-auth0"
-                      :sha "a123871641ebc0d868a6dcd72afe0afb19a9cafc"
+                      :sha "29a8ced9943a5cc6e20c14202c123a3f970b18f5"
                       :exclusions [com.auth0/jwks-rsa com.auth0/java-jwt]
                       }
         }

--- a/drafter-client/test/drafter_client/test_util/jwt.clj
+++ b/drafter-client/test/drafter_client/test_util/jwt.clj
@@ -26,7 +26,7 @@
       (.withIssuer (str iss \/))
       (.withSubject sub)
       (.withAudience (into-array String [aud]))
-      (.withExpiresAt (to-date (time/plus (time/now) (time/minutes 10))))
+      (.withExpiresAt (to-date (time/plus (time/now) (time/minutes 30))))
       (.withClaim "scope" role)
       (.sign alg)))
 


### PR DESCRIPTION
Whilst the tests for `client/add` use all of the 2252 triples in the test data file, I have also tested these changes by appending upwards of 4 million triples or quads to a draftset.

There was some talk about changing the function signature for `client/add`, but in the end, I decided that it would be better to keep the signature the same and so this will be backwards compatible and a drop-in replacement within muttnik; to immediately receive the benefits.