### PR TITLE
"Simplify" drafter dev/test Auth0 config

### DIFF
--- a/drafter/env/dev/resources/drafter-dev-auth0.edn
+++ b/drafter/env/dev/resources/drafter-dev-auth0.edn
@@ -1,32 +1,24 @@
 ;; This file is meta-merged over drafter-base-config.edn when the
 ;; system is launched via drafter.main.
 
-{
- :swirrl.auth0/client {:endpoint #env AUTH0_DOMAIN
-                       :audience "https://dev-kkt-m758.eu.auth0.com/api/v2/"
+{:swirrl.auth0/client {:endpoint #env AUTH0_DOMAIN
+                       :iss #env AUTH0_DOMAIN
+                       :aud #env AUTH0_AUD
+                       :api #join [#env AUTH0_DOMAIN "/api/v2/"]
                        :swagger-json #resource "swirrl/auth0/swagger.json"
-
-                       ;; TODO: We should probably set these ID's and secrets via env vars too
-                       :client-id "kXGEqpUE9aWRkMYe67cAxW4fNU2hpiMt"
-                       :client-secret "26kt07oo36e8yhmaJoz4OqgXpiMskhtC5BQYzT9v5fQcNXQLi8QKJO9RZD2Bb44N"}
+                       :client-id #env AUTH0_CLIENT_ID
+                       :client-secret #env AUTH0_CLIENT_SECRET}
 
  :drafter.user/auth0-repository {:auth0 #ig/ref :swirrl.auth0/client}
 
  :swirrl.auth0/jwk {:endpoint #env AUTH0_DOMAIN}
 
- :drafter.auth/auth0 {:iss #env AUTH0_DOMAIN
-                      :aud #env AUTH0_AUD
-                      :endpoint #env AUTH0_DOMAIN
-                      :client-id #env AUTH0_CLIENT_ID
-                      :client-secret #env AUTH0_CLIENT_SECRET}
-
  :swirrl.auth0.middleware/bearer-token
- {:auth0 #ig/ref :drafter.auth/auth0 :jwk #ig/ref :swirrl.auth0/jwk}
+ {:auth0 #ig/ref :swirrl.auth0/client :jwk #ig/ref :swirrl.auth0/jwk}
 
  :drafter.middleware.auth0-auth/identify {}
 
- :drafter.middleware.auth0-auth/token-authentication
- {:auth0 #ig/ref :drafter.auth/auth0 :jwk #ig/ref :swirrl.auth0/jwk}
+ :drafter.middleware.auth0-auth/token-authentication {}
 
  :drafter.middleware.auth0-auth/authorization {}
 

--- a/drafter/env/dev/resources/drafter-dev-config.edn
+++ b/drafter/env/dev/resources/drafter-dev-config.edn
@@ -1,6 +1,4 @@
-{
-
- :drafter.user/memory-repository {:users [{:username "editor@swirrl.com" :password "password" :role :editor}
+{:drafter.user/memory-repository {:users [{:username "editor@swirrl.com" :password "password" :role :editor}
                                           {:username "publisher@swirrl.com" :password "password" :role :publisher}
                                           {:username "manager@swirrl.com" :password "password" :role :manager}
                                           {:username "system@swirrl.com" :password "password" :role :system}]
@@ -8,23 +6,19 @@
 
  :drafter.auth.auth0/mock-jwk {:endpoint #env AUTH0_DOMAIN}
 
- :drafter.auth/auth0 {:iss #env AUTH0_DOMAIN
-                      :aud #env AUTH0_AUD
-                      :endpoint #env AUTH0_DOMAIN
-                      :client-id #env AUTH0_CLIENT_ID
-                      :client-secret #env AUTH0_CLIENT_SECRET}
-
- :swirrl.auth0.middleware/dev-token
- {:drafter.middleware.auth0-auth/access-token {:payload {:permissions ["drafter:admin"]}}
-  :drafter.middleware.auth0-auth/id-token {:payload {:name "Swirrly McSwirrlFace"}}}
+ ;; this config is using the memory-repo for user lookup, so will not use auth0 API
+ :swirrl.auth0/client {:iss #env AUTH0_DOMAIN
+                       :aud #env AUTH0_AUD
+                       :endpoint #env AUTH0_DOMAIN
+                       :client-id #env AUTH0_CLIENT_ID
+                       :client-secret #env AUTH0_CLIENT_SECRET}
 
  :swirrl.auth0.middleware/bearer-token
- {:auth0 #ig/ref :drafter.auth/auth0 :jwk #ig/ref :drafter.auth.auth0/mock-jwk}
+ {:auth0 #ig/ref :swirrl.auth0/client :jwk #ig/ref :drafter.auth.auth0/mock-jwk}
 
  :drafter.middleware.auth0-auth/identify {}
 
- :drafter.middleware.auth0-auth/token-authentication
- {:auth0 #ig/ref :drafter.auth/auth0 :jwk #ig/ref :drafter.auth.auth0/mock-jwk}
+ :drafter.middleware.auth0-auth/token-authentication {}
 
  :drafter.middleware.auth0-auth/authorization {}
 

--- a/drafter/test/resources/auth0-repo.edn
+++ b/drafter/test/resources/auth0-repo.edn
@@ -1,7 +1,2 @@
-{:swirrl.auth0/client {:endpoint #env AUTH0_DOMAIN
-                       :audience "https://dev-kkt-m758.eu.auth0.com/api/v2/"
-                       :api "https://dev-kkt-m758.eu.auth0.com/api/v2/"
-                       :swagger-json #resource "swirrl/auth0/swagger.json"
-                       :client-id "kXGEqpUE9aWRkMYe67cAxW4fNU2hpiMt"
-                       :client-secret "26kt07oo36e8yhmaJoz4OqgXpiMskhtC5BQYzT9v5fQcNXQLi8QKJO9RZD2Bb44N"}
- :drafter.user/auth0-repository {:auth0 #ig/ref :swirrl.auth0/client}}
+#merge [#include "swirrl-auth0.edn"
+        {:drafter.user/auth0-repository {:auth0 #ig/ref :swirrl.auth0/client}}]

--- a/drafter/test/resources/drafter/feature/draftset/claimable-draftset-changes-2.edn
+++ b/drafter/test/resources/drafter/feature/draftset/claimable-draftset-changes-2.edn
@@ -1,5 +1,6 @@
 #merge [#include "../../../backend.edn"
         #include "../../../repo.edn"
+        #include "../../../swirrl-auth0.edn"
         #include "../../../user-repo.edn"
         #include "../../../log-system.edn"
         #include "../../../web.edn"

--- a/drafter/test/resources/drafter/feature/draftset/claimable-draftset-changes.edn
+++ b/drafter/test/resources/drafter/feature/draftset/claimable-draftset-changes.edn
@@ -1,5 +1,6 @@
 #merge [#include "../../../backend.edn"
         #include "../../../repo.edn"
+        #include "../../../swirrl-auth0.edn"
         #include "../../../user-repo.edn"
         #include "../../../log-system.edn"
         #include "../../../web.edn"

--- a/drafter/test/resources/drafter/feature/draftset/list_test-1-draftset-with-submission.edn
+++ b/drafter/test/resources/drafter/feature/draftset/list_test-1-draftset-with-submission.edn
@@ -1,5 +1,6 @@
 #merge [#include "../../../backend.edn"
         #include "../../../repo.edn"
+        #include "../../../swirrl-auth0.edn"
         #include "../../../user-repo.edn"
         #include "../../../log-system.edn"
         #include "../../../web.edn"

--- a/drafter/test/resources/drafter/feature/draftset/list_test-1.edn
+++ b/drafter/test/resources/drafter/feature/draftset/list_test-1.edn
@@ -1,5 +1,6 @@
 #merge [#include "../../../backend.edn"
         #include "../../../repo.edn"
+        #include "../../../swirrl-auth0.edn"
         #include "../../../user-repo.edn"
         #include "../../../log-system.edn"
         #include "../../../web.edn"

--- a/drafter/test/resources/drafter/feature/draftset/list_test-2.edn
+++ b/drafter/test/resources/drafter/feature/draftset/list_test-2.edn
@@ -1,5 +1,6 @@
 #merge [#include "../../../backend.edn"
         #include "../../../repo.edn"
+        #include "../../../swirrl-auth0.edn"
         #include "../../../user-repo.edn"
         #include "../../../log-system.edn"
         #include "../../../web.edn"

--- a/drafter/test/resources/drafter/feature/draftset/list_test-unclaimable.edn
+++ b/drafter/test/resources/drafter/feature/draftset/list_test-unclaimable.edn
@@ -1,5 +1,6 @@
 #merge [#include "../../../backend.edn"
         #include "../../../repo.edn"
+        #include "../../../swirrl-auth0.edn"
         #include "../../../user-repo.edn"
         #include "../../../log-system.edn"
         #include "../../../web.edn"

--- a/drafter/test/resources/drafter/feature/empty-db-system.edn
+++ b/drafter/test/resources/drafter/feature/empty-db-system.edn
@@ -1,5 +1,6 @@
 #merge [#include "repo.edn"
         #include "backend.edn"
+        #include "swirrl-auth0.edn"
         #include "user-repo.edn"
         #include "log-system.edn"
         #include "web.edn"

--- a/drafter/test/resources/drafter/routes/sparql-test/graph-restriction-system.edn
+++ b/drafter/test/resources/drafter/routes/sparql-test/graph-restriction-system.edn
@@ -1,4 +1,5 @@
 #merge [#include "drafter/routes/sparql-test/repo.edn"
+        #include "swirrl-auth0.edn"
         #include "user-repo.edn"
         #include "log-system.edn"
         #include "web.edn"

--- a/drafter/test/resources/drafter/routes/sparql-test/reasoning-system.edn
+++ b/drafter/test/resources/drafter/routes/sparql-test/reasoning-system.edn
@@ -1,4 +1,5 @@
 #merge [#include "drafter/routes/sparql-test/repo.edn"
+        #include "swirrl-auth0.edn"
         #include "user-repo.edn"
         #include "log-system.edn"
         #include "web.edn"

--- a/drafter/test/resources/drafter/routes/sparql-test/system.edn
+++ b/drafter/test/resources/drafter/routes/sparql-test/system.edn
@@ -1,4 +1,5 @@
 #merge [#include "repo.edn"
+        #include "swirrl-auth0.edn"
         #include "user-repo.edn"
         #include "log-system.edn"
         #include "web.edn"

--- a/drafter/test/resources/swirrl-auth0.edn
+++ b/drafter/test/resources/swirrl-auth0.edn
@@ -1,0 +1,7 @@
+{:swirrl.auth0/client {:endpoint #env AUTH0_DOMAIN
+                       :iss #env AUTH0_DOMAIN
+                       :aud #env AUTH0_AUD
+                       :api #join [#env AUTH0_DOMAIN "/api/v2/"]
+                       :swagger-json #resource "swirrl/auth0/swagger.json"
+                       :client-id #env AUTH0_CLIENT_ID
+                       :client-secret #env AUTH0_CLIENT_SECRET}}

--- a/drafter/test/resources/test-system.edn
+++ b/drafter/test/resources/test-system.edn
@@ -1,5 +1,6 @@
 #merge [#include "repo.edn"
         #include "backend.edn"
+        #include "swirrl-auth0.edn"
         #profile {:auth0 #include "auth0-repo.edn"
                   :basic-auth #include "user-repo.edn"}
         #include "log-system.edn"

--- a/drafter/test/resources/web.edn
+++ b/drafter/test/resources/web.edn
@@ -1,19 +1,12 @@
 {
  :drafter.auth.auth0/mock-jwk {:endpoint #env AUTH0_DOMAIN}
 
- :drafter.auth/auth0 {:iss #env AUTH0_DOMAIN
-                      :aud #env AUTH0_AUD
-                      :endpoint #env AUTH0_DOMAIN
-                      :client-id #env AUTH0_CLIENT_ID
-                      :client-secret #env AUTH0_CLIENT_SECRET}
-
  :swirrl.auth0.middleware/bearer-token
- {:auth0 #ig/ref :drafter.auth/auth0 :jwk #ig/ref :drafter.auth.auth0/mock-jwk}
+ {:auth0 #ig/ref :swirrl.auth0/client :jwk #ig/ref :drafter.auth.auth0/mock-jwk}
 
  :drafter.middleware.auth0-auth/identify {}
 
- :drafter.middleware.auth0-auth/token-authentication
- {:auth0 #ig/ref :drafter.auth/auth0 :jwk #ig/ref :drafter.auth.auth0/mock-jwk}
+ :drafter.middleware.auth0-auth/token-authentication {}
 
  :drafter.middleware.auth0-auth/authorization {}
 

--- a/package/install/drafter-prod-auth0.edn
+++ b/package/install/drafter-prod-auth0.edn
@@ -3,30 +3,25 @@
 
 {
  :swirrl.auth0/client {:endpoint #env AUTH0_DOMAIN
-                       :audience "https://dev-kkt-m758.eu.auth0.com/api/v2/"
+                       :iss #env AUTH0_DOMAIN
+                       :aud #env AUTH0_AUD
+                       :api #join [#env AUTH0_DOMAIN "/api/v2/"]
                        :swagger-json #resource "swirrl/auth0/swagger.json"
-
-                       ;; TODO: We should probably set these ID's and secrets via env vars too
-                       :client-id "kXGEqpUE9aWRkMYe67cAxW4fNU2hpiMt"
-                       :client-secret "26kt07oo36e8yhmaJoz4OqgXpiMskhtC5BQYzT9v5fQcNXQLi8QKJO9RZD2Bb44N"}
+                       :client-id #env AUTH0_CLIENT_ID
+                       :client-secret #env AUTH0_CLIENT_SECRET}
 
  :drafter.user/auth0-repository {:auth0 #ig/ref :swirrl.auth0/client}
 
  :swirrl.auth0/jwk {:endpoint #env AUTH0_DOMAIN}
 
- :drafter.auth/auth0 {:iss #env AUTH0_DOMAIN
-                      :aud #env AUTH0_AUD
-                      :endpoint #env AUTH0_DOMAIN
-                      :client-id #env AUTH0_CLIENT_ID
-                      :client-secret #env AUTH0_CLIENT_SECRET}
-
  :swirrl.auth0.middleware/bearer-token
- {:auth0 #ig/ref :drafter.auth/auth0 :jwk #ig/ref :swirrl.auth0/jwk}
+ {:auth0 #ig/ref :swirrl.auth0/client :jwk #ig/ref :swirrl.auth0/jwk}
 
  :drafter.middleware.auth0-auth/identify {}
 
- :drafter.middleware.auth0-auth/token-authentication
- {:auth0 #ig/ref :drafter.auth/auth0 :jwk #ig/ref :swirrl.auth0/jwk}
+ :drafter.middleware.auth0-auth/token-authentication {}
+
+ :drafter.middleware.auth0-auth/authorization {}
 
  :drafter.auth/read-role {}
  :swirrl.auth0.middleware/normalize-roles {:role-reader #ig/ref :drafter.auth/read-role}


### PR DESCRIPTION
Simplifies drafter's auth0 config in dev/test envs by removing legacy `:drafter.auth/auth0` config.