### PR TITLE
Configure stasher to be off in the omni dev package we export

### DIFF
--- a/package/install/dev-start-auth0.sh
+++ b/package/install/dev-start-auth0.sh
@@ -5,7 +5,7 @@ cd {{omni/install-dir}}
 set -o allexport
 source dev-settings.env
 
-java -jar ./drafter.jar drafter-dev-auth0.edn &
+java -jar ./drafter.jar drafter-dev-auth0.edn stasher-off.edn &
 
 #TODO: wait for drafter to become available
 echo $! > drafter.pid

--- a/package/install/dev-start-basic-auth.sh
+++ b/package/install/dev-start-basic-auth.sh
@@ -5,7 +5,7 @@ cd {{omni/install-dir}}
 set -o allexport
 source dev-settings.env
 
-java -jar ./drafter.jar drafter-dev-basic-auth-memory-db.edn &
+java -jar ./drafter.jar drafter-dev-basic-auth-memory-db.edn stasher-off.edn &
 
 #TODO: wait for drafter to become available
 echo $! > drafter.pid

--- a/package/install/stasher-off.edn
+++ b/package/install/stasher-off.edn
@@ -1,0 +1,6 @@
+{
+ :drafter.stasher/repo {;; Switch stasher caching off.  This is
+                        ;; advisable in dev environments.
+                        :cache? false}
+
+ }

--- a/package/pmd3-manifest.edn
+++ b/package/pmd3-manifest.edn
@@ -33,6 +33,10 @@
                                       {:type :copy
                                        :path "drafter-dev-basic-auth-memory-db.edn"
                                        :mode "644"
+                                       :env #{:dev :ci}}
+                                      {:type :copy
+                                       :path "stasher-off.edn"
+                                       :mode "644"
                                        :env #{:dev :ci}}]}
 
               :omni/package-name "drafter-pmd3"

--- a/package/pmd4-manifest.edn
+++ b/package/pmd4-manifest.edn
@@ -33,4 +33,9 @@
                                        :mode "644"
                                        :env #{:dev :ci}
                                        }
+                                      {:type :copy
+                                       :path "stasher-off.edn"
+                                       :mode "644"
+                                       :env #{:dev :ci}
+                                       }
                                       ]}}]


### PR DESCRIPTION
This is because caching can often interfere with development in two
ways:

1. It can mask performance issues and make you think things are faster
   than they are.
2. If you mutate the data behind drafter you may get
   misleading/incorrect results, resulting in wasted time
   chasing red herrings.