### PR TITLE
Extract the global-writes-lock into an integrant component

### DIFF
--- a/drafter/resources/drafter-base-config.edn
+++ b/drafter/resources/drafter-base-config.edn
@@ -39,6 +39,7 @@
  :drafter.backend.live/endpoint {:repo #ig/ref :drafter.stasher/repo}
 
  :drafter/backend {:repo #ig/ref :drafter.stasher/repo}
+ :drafter/global-writes-lock {:fairness true :time 10 :unit :seconds}
 
 
  ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -63,12 +64,14 @@
                                          :wrap-auth #ig/ref :drafter.middleware/wrap-auth}
 
  :drafter.feature.draftset.create/handler {:drafter/backend #ig/ref :drafter/backend
+                                           :drafter/global-writes-lock #ig/ref :drafter/global-writes-lock
                                            :wrap-auth #ig/ref :drafter.middleware/wrap-auth}
 
  :drafter.feature.middleware/wrap-as-draftset-owner {:drafter/backend #ig/ref :drafter/backend
-                                                       :wrap-auth #ig/ref :drafter.middleware/wrap-auth}
+                                                     :wrap-auth #ig/ref :drafter.middleware/wrap-auth}
 
  :drafter.feature.draftset.delete/handler {:drafter/backend #ig/ref :drafter/backend
+                                           :drafter/global-writes-lock #ig/ref :drafter/global-writes-lock
                                            :wrap-as-draftset-owner #ig/ref :drafter.feature.middleware/wrap-as-draftset-owner}
 
  :drafter.feature.draftset.options/handler {:drafter/backend #ig/ref :drafter/backend
@@ -79,19 +82,24 @@
                                               :timeout-fn #ig/ref [:drafter.timeouts/timeout-query :drafter/draftset-timeout]}
 
  :drafter.feature.draftset-data.delete/delete-data-handler {:drafter/backend #ig/ref :drafter/backend
-                                                             :wrap-as-draftset-owner #ig/ref :drafter.feature.middleware/wrap-as-draftset-owner}
+                                                            :drafter/global-writes-lock #ig/ref :drafter/global-writes-lock
+                                                            :wrap-as-draftset-owner #ig/ref :drafter.feature.middleware/wrap-as-draftset-owner}
 
  :drafter.feature.draftset-data.delete-by-graph/remove-graph-handler {:drafter/backend #ig/ref :drafter/backend
-                                                              :wrap-as-draftset-owner #ig/ref :drafter.feature.middleware/wrap-as-draftset-owner}
+                                                                      :drafter/global-writes-lock #ig/ref :drafter/global-writes-lock
+                                                                      :wrap-as-draftset-owner #ig/ref :drafter.feature.middleware/wrap-as-draftset-owner}
 
  :drafter.feature.draftset.changes/delete-changes-handler {:drafter/backend #ig/ref :drafter/backend
-                                                                :wrap-as-draftset-owner #ig/ref :drafter.feature.middleware/wrap-as-draftset-owner}
+                                                           :drafter/global-writes-lock #ig/ref :drafter/global-writes-lock
+                                                           :wrap-as-draftset-owner #ig/ref :drafter.feature.middleware/wrap-as-draftset-owner}
 
  :drafter.feature.draftset-data.append/data-handler {:drafter/backend #ig/ref :drafter/backend
-                                                                  :wrap-as-draftset-owner #ig/ref :drafter.feature.middleware/wrap-as-draftset-owner}
+                                                     :drafter/global-writes-lock #ig/ref :drafter/global-writes-lock
+                                                     :wrap-as-draftset-owner #ig/ref :drafter.feature.middleware/wrap-as-draftset-owner}
 
  :drafter.feature.draftset-data.append-by-graph/handler {:drafter/backend #ig/ref :drafter/backend
-                                                           :wrap-as-draftset-owner #ig/ref :drafter.feature.middleware/wrap-as-draftset-owner}
+                                                         :drafter/global-writes-lock #ig/ref :drafter/global-writes-lock
+                                                         :wrap-as-draftset-owner #ig/ref :drafter.feature.middleware/wrap-as-draftset-owner}
 
  :drafter.feature.draftset.query/handler {:drafter/backend #ig/ref :drafter/backend
                                           :wrap-as-draftset-owner #ig/ref :drafter.feature.middleware/wrap-as-draftset-owner
@@ -101,13 +109,16 @@
                                             :wrap-as-draftset-owner #ig/ref :drafter.feature.middleware/wrap-as-draftset-owner}
 
  :drafter.feature.draftset.set-metadata/handler {:drafter/backend #ig/ref :drafter/backend
+                                                 :drafter/global-writes-lock #ig/ref :drafter/global-writes-lock
                                                  :wrap-as-draftset-owner #ig/ref :drafter.feature.middleware/wrap-as-draftset-owner}
 
  :drafter.feature.draftset.submit/handler {:drafter/backend #ig/ref :drafter/backend
+                                           :drafter/global-writes-lock #ig/ref :drafter/global-writes-lock
                                            :drafter.user/repo #ig/ref :drafter.user/repo
                                            :wrap-as-draftset-owner #ig/ref :drafter.feature.middleware/wrap-as-draftset-owner}
 
  :drafter.feature.draftset.claim/handler {:wrap-auth #ig/ref :drafter.middleware/wrap-auth
+                                          :drafter/global-writes-lock #ig/ref :drafter/global-writes-lock
                                           :drafter/backend #ig/ref :drafter/backend}
 
  #_:drafter.routes.draftsets-api/get-users-handler
@@ -136,7 +147,8 @@
  :drafter.handler/app {:repo #ig/ref :drafter.stasher/repo
                        :live-sparql-query-route #ig/ref :drafter.routes.sparql/live-sparql-query-route
                        :draftset-api-routes #ig/ref :drafter.routes/draftsets-api
-                       :jobs-status-routes #ig/ref :drafter.routes/jobs-status}
+                       :jobs-status-routes #ig/ref :drafter.routes/jobs-status
+                       :drafter/global-writes-lock #ig/ref :drafter/global-writes-lock}
 
  ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
  ;; Web Server
@@ -153,7 +165,8 @@
  ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 
- :drafter/write-scheduler {:port #long #or [#port #env DRAFTER_HTTP_PORT 3001]}
+ :drafter/write-scheduler {:port #long #or [#port #env DRAFTER_HTTP_PORT 3001]
+                           :drafter/global-writes-lock #ig/ref :drafter/global-writes-lock}
 
  ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
  ;; logging

--- a/drafter/src/drafter/feature/common.clj
+++ b/drafter/src/drafter/feature/common.clj
@@ -18,9 +18,9 @@
         (ajobs/job-succeeded! job result)))))
 
 (defn run-sync
-  ([backend user-id operation draftset-id api-call-fn]
-   (response/run-sync-job!
+  ([{:keys [backend global-writes-lock]} user-id operation draftset-id api-call-fn]
+   (response/run-sync-job! global-writes-lock
     (as-sync-write-job backend user-id operation draftset-id api-call-fn)))
-  ([backend user-id operation draftset-id api-call-fn resp-fn]
-   (response/run-sync-job!
+  ([{:keys [backend global-writes-lock]} user-id operation draftset-id api-call-fn resp-fn]
+   (response/run-sync-job! global-writes-lock
     (as-sync-write-job backend user-id operation draftset-id api-call-fn) resp-fn)))

--- a/drafter/src/drafter/feature/draftset/changes.clj
+++ b/drafter/src/drafter/feature/draftset/changes.clj
@@ -26,13 +26,14 @@
       :reverted)
     :not-found))
 
-(defn delete-draftset-changes-handler [{backend :drafter/backend wrap-as-draftset-owner :wrap-as-draftset-owner}]
+(defn delete-draftset-changes-handler
+  [{:keys [:drafter/backend :drafter/global-writes-lock wrap-as-draftset-owner]}]
   (wrap-as-draftset-owner
    (middleware/parse-graph-param-handler
     true
     (fn [{{:keys [draftset-id graph]} :params :as request}]
       (feat-common/run-sync
-       backend
+       {:backend backend :global-writes-lock global-writes-lock}
        (req/user-id request)
        'delete-draftset-changes
        draftset-id
@@ -44,9 +45,9 @@
              (ring/response (dsops/get-draftset-info backend draftset-id))
              (ring/not-found "")))))))))
 
-(defmethod ig/pre-init-spec ::delete-changes-handler [_]
-  (s/keys :req [:drafter/backend]
+(defmethod ig/pre-init-spec :drafter.feature.draftset.changes/delete-changes-handler [_]
+  (s/keys :req [:drafter/backend :drafter/global-writes-lock]
           :req-un [::wrap-as-draftset-owner]))
 
-(defmethod ig/init-key ::delete-changes-handler [_ opts]
+(defmethod ig/init-key :drafter.feature.draftset.changes/delete-changes-handler [_ opts]
   (delete-draftset-changes-handler opts))

--- a/drafter/src/drafter/feature/draftset/publish.clj
+++ b/drafter/src/drafter/feature/draftset/publish.clj
@@ -19,9 +19,9 @@
                                      util/get-current-time))
        (forbidden-response "You require the publisher role to perform this action")))))
 
-(defmethod ig/pre-init-spec ::handler [_]
+(defmethod ig/pre-init-spec :drafter.feature.draftset.publish/handler [_]
   (s/keys :req [:drafter/backend]
           :req-un [::wrap-as-draftset-owner]))
 
-(defmethod ig/init-key ::handler [_ opts]
+(defmethod ig/init-key :drafter.feature.draftset.publish/handler [_ opts]
   (handler opts))

--- a/drafter/src/drafter/feature/draftset/set_metadata.clj
+++ b/drafter/src/drafter/feature/draftset/set_metadata.clj
@@ -6,20 +6,20 @@
             [drafter.requests :as req]))
 
 (defn handler
-  [{backend :drafter/backend :keys [wrap-as-draftset-owner timeout-fn]}]
+  [{:keys [:drafter/backend :drafter/global-writes-lock wrap-as-draftset-owner timeout-fn]}]
   (wrap-as-draftset-owner
    (fn [{{:keys [draftset-id] :as params} :params :as request}]
      (feat-common/run-sync
-      backend
+      {:backend backend :global-writes-lock global-writes-lock}
       (req/user-id request)
       'set-draftset-metadata
       draftset-id
       #(dsops/set-draftset-metadata! backend draftset-id params)
       #(feat-common/draftset-sync-write-response % backend draftset-id)))))
 
-(defmethod ig/pre-init-spec ::handler [_]
-  (s/keys :req [:drafter/backend]
+(defmethod ig/pre-init-spec :drafter.feature.draftset.set-metadata/handler [_]
+  (s/keys :req [:drafter/backend :drafter/global-writes-lock]
           :req-un [::wrap-as-draftset-owner]))
 
-(defmethod ig/init-key ::handler [_ opts]
+(defmethod ig/init-key :drafter.feature.draftset.set-metadata/handler [_ opts]
   (handler opts))

--- a/drafter/src/drafter/feature/draftset/submit.clj
+++ b/drafter/src/drafter/feature/draftset/submit.clj
@@ -7,10 +7,10 @@
             [integrant.core :as ig]))
 
 (defn handle-user
-  [backend repo user draftset-id owner]
+  [{:keys [backend] :as resources} repo user draftset-id owner]
   (if-let [target-user (user/find-user-by-username repo user)]
     (feat-common/run-sync
-     backend
+     resources
      (:email owner)
      'submit-draftset-to-user
      draftset-id
@@ -19,11 +19,11 @@
     (unprocessable-entity-response (str "User: " user " not found"))))
 
 (defn handle-role
-  [backend role draftset-id owner]
+  [{:keys [backend] :as resources} role draftset-id owner]
   (let [role-kw (keyword role)]
     (if (user/is-known-role? role-kw)
       (feat-common/run-sync
-       backend
+       resources
        (:email owner)
        'submit-draftset-to-role
        draftset-id
@@ -32,27 +32,28 @@
       (unprocessable-entity-response (str "Invalid role: " role)))))
 
 (defn handler
-  [{:keys [:drafter/backend :drafter.user/repo
+  [{:keys [:drafter/backend :drafter/global-writes-lock :drafter.user/repo
            wrap-as-draftset-owner timeout-fn]}]
-  (wrap-as-draftset-owner
-   (fn [{{:keys [user role draftset-id]} :params owner :identity}]
-     (cond
-       (and (some? user) (some? role))
-       (unprocessable-entity-response
-        "Only one of user and role parameters permitted")
+  (let [resources {:backend backend :global-writes-lock global-writes-lock}]
+    (wrap-as-draftset-owner
+     (fn [{{:keys [user role draftset-id]} :params owner :identity}]
+       (cond
+         (and (some? user) (some? role))
+         (unprocessable-entity-response
+          "Only one of user and role parameters permitted")
 
-       (some? user)
-       (handle-user backend repo user draftset-id owner)
+         (some? user)
+         (handle-user resources repo user draftset-id owner)
 
-       (some? role)
-       (handle-role backend role draftset-id owner)
+         (some? role)
+         (handle-role resources role draftset-id owner)
 
-       :else
-       (unprocessable-entity-response "user or role parameter required")))))
+         :else
+         (unprocessable-entity-response "user or role parameter required"))))))
 
-(defmethod ig/pre-init-spec ::handler [_]
-  (s/keys :req [:drafter/backend ::user/repo]
+(defmethod ig/pre-init-spec :drafter.feature.draftset.submit/handler [_]
+  (s/keys :req [:drafter/backend :drafter/global-writes-lock ::user/repo]
           :req-un [::wrap-as-draftset-owner]))
 
-(defmethod ig/init-key ::handler [_ opts]
+(defmethod ig/init-key :drafter.feature.draftset.submit/handler [_ opts]
   (handler opts))

--- a/drafter/src/drafter/feature/draftset_data/common.clj
+++ b/drafter/src/drafter/feature/draftset_data/common.clj
@@ -44,11 +44,11 @@
   "Calls mgmt/copy-graph to copy a live graph into the draftset, but
   does so with the writes lock engaged.  This allows us to fail
   concurrent sync-writes fast."
-  [backend live-graph-uri draft-graph-uri opts]
-  (writes/with-lock :copy-graph
+  [resources live-graph-uri draft-graph-uri opts]
+  (writes/with-lock (:global-writes-lock resources) :copy-graph
     ;; Execute the graph copy inside the write-lock so we can
     ;; fail :blocking-write operations if they are waiting longer than
     ;; their timeout period for us to release it.  These writes would
     ;; likely be blocked inside the database anyway, so this way we
     ;; can fail them fast when they are run behind a long running op.
-    (mgmt/copy-graph backend live-graph-uri draft-graph-uri opts)))
+    (mgmt/copy-graph (:backend resources) live-graph-uri draft-graph-uri opts)))

--- a/drafter/src/drafter/feature/draftset_data/delete_by_graph.clj
+++ b/drafter/src/drafter/feature/draftset_data/delete_by_graph.clj
@@ -15,27 +15,28 @@
 
 (defn remove-graph-from-draftset-handler
   "Remove a supplied graph from the draftset."
-  [{backend :drafter/backend wrap-as-draftset-owner :wrap-as-draftset-owner}]
-  (wrap-as-draftset-owner
-   (parse-query-param-flag-handler
-    :silent
-    (feat-middleware/parse-graph-param-handler
-     true
-     (fn [{{:keys [draftset-id graph silent]} :params :as request}]
-       (if (mgmt/is-graph-managed? backend graph)
-         (feat-common/run-sync backend
-                               (req/user-id request)
-                               'delete-draftset-graph
-                               draftset-id
-                               #(dsops/delete-draftset-graph! backend draftset-id graph util/get-current-time)
-                               #(feat-common/draftset-sync-write-response % backend draftset-id))
-         (if silent
-           (ring/response (dsops/get-draftset-info backend draftset-id))
-           (drafter-response/unprocessable-entity-response (str "Graph not found")))))))))
+  [{:keys [:drafter/backend :drafter/global-writes-lock wrap-as-draftset-owner]}]
+  (let [resources {:backend backend :global-writes-lock global-writes-lock}]
+    (wrap-as-draftset-owner
+     (parse-query-param-flag-handler
+      :silent
+      (feat-middleware/parse-graph-param-handler
+       true
+       (fn [{{:keys [draftset-id graph silent]} :params :as request}]
+         (if (mgmt/is-graph-managed? backend graph)
+           (feat-common/run-sync resources
+                                 (req/user-id request)
+                                 'delete-draftset-graph
+                                 draftset-id
+                                 #(dsops/delete-draftset-graph! backend draftset-id graph util/get-current-time)
+                                 #(feat-common/draftset-sync-write-response % backend draftset-id))
+           (if silent
+             (ring/response (dsops/get-draftset-info backend draftset-id))
+             (drafter-response/unprocessable-entity-response (str "Graph not found"))))))))))
 
-(defmethod ig/pre-init-spec ::remove-graph-handler [_]
-  (s/keys :req [:drafter/backend]
+(defmethod ig/pre-init-spec :drafter.feature.draftset-data.delete-by-graph/remove-graph-handler [_]
+  (s/keys :req [:drafter/backend :drafter/global-writes-lock]
           :req-un [::wrap-as-draftset-owner]))
 
-(defmethod ig/init-key ::remove-graph-handler [_ opts]
+(defmethod ig/init-key :drafter.feature.draftset-data.delete-by-graph/remove-graph-handler [_ opts]
   (remove-graph-from-draftset-handler opts))

--- a/drafter/src/drafter/handler.clj
+++ b/drafter/src/drafter/handler.clj
@@ -13,8 +13,7 @@
             [drafter.timeouts :as timeouts]
             [drafter.util :refer [conj-if set-var-root!]]
             [drafter.write-scheduler
-             :refer
-             [global-writes-lock start-writer! stop-writer!]]
+             :refer [start-writer! stop-writer!]]
             [integrant.core :as ig]
             [noir.util.middleware :refer [app-handler]]
             [ring.middleware.defaults :refer [api-defaults]]
@@ -47,7 +46,8 @@
   [{backend :repo
     live-sparql-route :live-sparql-query-route
     draftset-api-routes :draftset-api-routes
-    jobs-status-routes :jobs-status-routes}]
+    jobs-status-routes :jobs-status-routes
+    global-writes-lock :drafter/global-writes-lock}]
   (wrap-handler (app-handler
                  ;; add your application routes here
                  (-> []

--- a/drafter/src/drafter/responses.clj
+++ b/drafter/src/drafter/responses.clj
@@ -44,8 +44,8 @@
     (r/api-response 500 result)
     (r/api-response 200 result)))
 
-;; run-sync-job! :: Job -> RingResponse
-;; run-sync-job! :: Job -> (ApiResponse -> RingResponse) -> RingResponse
+;; run-sync-job! :: WriteLock -> Job -> RingResponse
+;; run-sync-job! :: WriteLock -> Job -> (ApiResponse -> RingResponse) -> RingResponse
 (defn run-sync-job!
   "Runs a sync job, blocks waiting for it to complete and returns a
   ring response using the given handler function. The handler function
@@ -53,11 +53,12 @@
   ring result map. If no handler is provided, the default job handler
   is used. If the job could not be queued, then a 503 'unavailable'
   response is returned."
-  ([job] (run-sync-job! job default-job-result-handler))
-  ([job resp-fn]
+  ([global-writes-lock job]
+   (run-sync-job! global-writes-lock job default-job-result-handler))
+  ([global-writes-lock job resp-fn]
    (log/info "Submitting sync job: " job)
    (try
-     (let [job-result (exec-sync-job! job)]
+     (let [job-result (exec-sync-job! global-writes-lock job)]
        (resp-fn job-result)))))
 
 ;; submit-async-job! :: Job -> RingResponse

--- a/drafter/src/drafter/routes/status.clj
+++ b/drafter/src/drafter/routes/status.clj
@@ -1,7 +1,6 @@
 (ns drafter.routes.status
   (:require [compojure.core :refer [GET routes]]))
 
-(defn status-routes [writes-lock]
+(defn status-routes [{:keys [lock]}]
   (routes
-   (GET "/writes-locked" []
-        (str (.isLocked writes-lock)))))
+   (GET "/writes-locked" [] (str (.isLocked lock)))))

--- a/drafter/test/drafter/async/jobs_test.clj
+++ b/drafter/test/drafter/async/jobs_test.clj
@@ -170,9 +170,10 @@
         (is (= {:type :ok :restart-id r/restart-id} body))))))
 
 (tc/deftest-system-with-keys jobs-list-status-test
-  [:drafter.routes/jobs-status]
+  [:drafter.routes/jobs-status :drafter/global-writes-lock]
   [{handler :drafter.routes/jobs-status
-    backend :drafter/backend :as sys} system]
+    backend :drafter/backend
+    global-writes-lock :drafter/global-writes-lock :as sys} system]
   (let [job (jobs/create-job dummy 'test-job :batch-write (constantly nil))
         path "/v1/status/jobs"]
 
@@ -191,7 +192,9 @@
         (is (= :pending (:status (first body))))))
 
     (testing "Synchronous jobs do not show up in :complete jobs"
-      (let [job (feat-common/run-sync backend dummy 'test-sync-job nil (constantly nil))]
+      (let [job (feat-common/run-sync {:backend backend
+                                       :global-writes-lock global-writes-lock}
+                                      dummy 'test-sync-job nil (constantly nil))]
         (let [{:keys [body status] :as response}
               (handler (tc/with-identity test-editor (request :get path)))]
           (is (= 200 status))

--- a/drafter/test/drafter/feature/draftset/delete_test.clj
+++ b/drafter/test/drafter/feature/draftset/delete_test.clj
@@ -238,7 +238,7 @@
       (is (= expected-quads quads-after-delete)))))
 
 (tc/deftest-system-with-keys delete-all-triples-from-graph
-  [:drafter.fixture-data/loader :drafter.routes/draftsets-api :drafter/write-scheduler]
+  [:drafter.fixture-data/loader :drafter.routes/draftsets-api :drafter/write-scheduler :drafter/global-writes-lock]
   [{handler :drafter.routes/draftsets-api} system]
   (let [quads (statements "test/resources/test-draftset.trig")
         grouped-quads (group-by context quads)

--- a/drafter/test/drafter/feature/draftset_data/append_test.clj
+++ b/drafter/test/drafter/feature/draftset_data/append_test.clj
@@ -21,12 +21,13 @@
 (def dummy "dummy@user.com")
 
 (tc/deftest-system append-data-to-draftset-job-test
-  [{:keys [:drafter/backend]} "drafter/rdf/draftset-management/jobs.edn"]
+  [{:keys [:drafter/backend :drafter/global-writes-lock]} "drafter/rdf/draftset-management/jobs.edn"]
   (let [initial-time (constantly (OffsetDateTime/parse "2017-01-01T01:01:01Z"))
         update-time  (constantly (OffsetDateTime/parse "2018-01-01T01:01:01Z") )
         delete-time  (constantly (OffsetDateTime/parse "2019-01-01T01:01:01Z"))
-        ds (dsops/create-draftset! backend test-editor)]
-    (th/apply-job! (sut/append-triples-to-draftset-job backend
+        ds (dsops/create-draftset! backend test-editor)
+        resources {:backend backend :global-writes-lock global-writes-lock}]
+    (th/apply-job! (sut/append-triples-to-draftset-job resources
                                                        dummy
                                                        ds
                                                        (io/file "./test/test-triple.nt")
@@ -36,7 +37,7 @@
     (let [ts-1 (th/ensure-draftgraph-and-draftset-modified backend ds "http://foo/graph")]
       (t/is (= (.toEpochSecond (initial-time))
                (.toEpochSecond ts-1)))
-      (th/apply-job! (sut/append-triples-to-draftset-job backend
+      (th/apply-job! (sut/append-triples-to-draftset-job resources
                                                          dummy
                                                          ds
                                                          (io/file "./test/test-triple-2.nt")

--- a/drafter/test/drafter/feature/draftset_data/delete_test.clj
+++ b/drafter/test/drafter/feature/draftset_data/delete_test.clj
@@ -20,21 +20,22 @@
 (def dummy "dummy@user.com")
 
 (tc/deftest-system-with-keys delete-draftset-data-test
-  [:drafter/backend :drafter/write-scheduler :drafter.fixture-data/loader]
-  [{:keys [:drafter/backend]} system]
+  [:drafter/backend :drafter/global-writes-lock :drafter/write-scheduler :drafter.fixture-data/loader]
+  [{:keys [:drafter/backend :drafter/global-writes-lock]} system]
   (let [initial-time (constantly (OffsetDateTime/parse "2017-01-01T01:01:01Z"))
         update-time (constantly (OffsetDateTime/parse "2018-01-01T01:01:01Z"))
         delete-time (constantly (OffsetDateTime/parse "2019-01-01T01:01:01Z"))
-        ds (dsops/create-draftset! backend test-editor)]
+        ds (dsops/create-draftset! backend test-editor)
+        resources {:backend backend :global-writes-lock global-writes-lock}]
 
-    (th/apply-job! (append/append-triples-to-draftset-job backend
+    (th/apply-job! (append/append-triples-to-draftset-job resources
                                                           dummy
                                                           ds
                                                           (io/file "./test/test-triple.nt")
                                                           RDFFormat/NTRIPLES
                                                           (URI. "http://foo/graph") initial-time))
 
-    (th/apply-job! (sut/delete-triples-from-draftset-job backend
+    (th/apply-job! (sut/delete-triples-from-draftset-job resources
                                                          dummy
                                                          ds
                                                          (URI. "http://foo/graph")

--- a/drafter/test/drafter/rdf/draftset_management/jobs_test.clj
+++ b/drafter/test/drafter/rdf/draftset_management/jobs_test.clj
@@ -20,12 +20,13 @@
 
 (tc/deftest-system copy-live-graph-into-draftset-test
   ;; TODO port to use a test fixture
-  [{:keys [:drafter/backend]} "drafter/rdf/draftset-management/jobs.edn"]
-  (let [draftset-id (dsops/create-draftset! backend test-editor)
+  [{:keys [:drafter/backend :drafter/global-writes-lock]} "drafter/rdf/draftset-management/jobs.edn"]
+  (let [resources {:backend backend :global-writes-lock global-writes-lock}
+        draftset-id (dsops/create-draftset! backend test-editor)
         live-triples (tc/test-triples (URI. "http://test-subject"))
         live-graph-uri (tc/make-graph-live! backend (URI. "http://live") live-triples (constantly #inst "2015"))
         {:keys [value-p] :as copy-job} (append-graph/copy-live-graph-into-draftset-job
-                                        backend
+                                        resources
                                         dummy
                                         draftset-id
                                         live-graph-uri)]
@@ -38,14 +39,15 @@
       (t/is (= (set live-triples) (set draft-triples))))))
 
 (tc/deftest-system copy-live-graph-into-existing-draft-graph-in-draftset-test
-  [{:keys [:drafter/backend]} "drafter/rdf/draftset-management/jobs.edn"]
-  (let [draftset-id (dsops/create-draftset! backend test-editor)
+  [{:keys [:drafter/backend :drafter/global-writes-lock]} "drafter/rdf/draftset-management/jobs.edn"]
+  (let [resources {:backend backend :global-writes-lock global-writes-lock}
+        draftset-id (dsops/create-draftset! backend test-editor)
         live-triples (tc/test-triples (URI. "http://test-subject"))
         live-graph-uri (tc/make-graph-live! backend (URI. "http://live") live-triples (constantly #inst "2015"))
         initial-draft-triples (tc/test-triples (URI. "http://temp-subject"))
         draft-graph-uri (tc/import-data-to-draft! backend live-graph-uri initial-draft-triples draftset-id (constantly #inst "2016"))
         {:keys [value-p] :as copy-job} (append-graph/copy-live-graph-into-draftset-job
-                                        backend
+                                        resources
                                         dummy
                                         draftset-id
                                         live-graph-uri)]

--- a/drafter/test/drafter/routes/status_test.clj
+++ b/drafter/test/drafter/routes/status_test.clj
@@ -30,7 +30,7 @@
 
 (deftest writes-lock-test
   (let [lock (ReentrantLock.)
-        status-route (status-routes lock)]
+        status-route (status-routes {:lock lock})]
 
     (testing "GET /writes-locked"
       (testing "when unlocked"

--- a/drafter/test/resources/drafter/routes/sparql-test/repo.edn
+++ b/drafter/test/resources/drafter/routes/sparql-test/repo.edn
@@ -24,10 +24,12 @@
  :drafter.backend.live/endpoint {:repo #ig/ref :drafter.stasher/repo}
 
  :drafter/backend {:repo #ig/ref :drafter.stasher/repo}
+ :drafter/global-writes-lock {:fairness true :time 10 :unit :seconds}
 
  :drafter.backend.draftset/endpoint {:repo #ig/ref :drafter.stasher/repo}
 
 
- :drafter/write-scheduler {:port #long #or [#port #env DRAFTER_HTTP_PORT 3003]}
+ :drafter/write-scheduler {:port #long #or [#port #env DRAFTER_HTTP_PORT 3003]
+                           :drafter/global-writes-lock #ig/ref :drafter/global-writes-lock}
 
  }

--- a/drafter/test/resources/repo.edn
+++ b/drafter/test/resources/repo.edn
@@ -23,10 +23,12 @@
  :drafter.backend.live/endpoint {:repo #ig/ref :drafter.stasher/repo}
 
  :drafter/backend {:repo #ig/ref :drafter.stasher/repo}
+ :drafter/global-writes-lock {:fairness true :time 10 :unit :seconds}
 
  :drafter.backend.draftset/endpoint {:repo #ig/ref :drafter.stasher/repo}
 
 
- :drafter/write-scheduler {:port #long #or [#port #env DRAFTER_HTTP_PORT 3003]}
+ :drafter/write-scheduler {:port #long #or [#port #env DRAFTER_HTTP_PORT 3003]
+                           :drafter/global-writes-lock #ig/ref :drafter/global-writes-lock}
 
  }

--- a/drafter/test/resources/web.edn
+++ b/drafter/test/resources/web.edn
@@ -55,12 +55,14 @@
 
 
  :drafter.feature.draftset.create/handler {:drafter/backend #ig/ref :drafter/backend
-                                                         :wrap-auth #ig/ref :drafter.middleware/wrap-auth}
+                                           :drafter/global-writes-lock #ig/ref :drafter/global-writes-lock
+                                           :wrap-auth #ig/ref :drafter.middleware/wrap-auth}
 
  :drafter.feature.middleware/wrap-as-draftset-owner {:drafter/backend #ig/ref :drafter/backend
                                                        :wrap-auth #ig/ref :drafter.middleware/wrap-auth}
 
  :drafter.feature.draftset.delete/handler {:drafter/backend #ig/ref :drafter/backend
+                                           :drafter/global-writes-lock #ig/ref :drafter/global-writes-lock
                                            :wrap-as-draftset-owner #ig/ref :drafter.feature.middleware/wrap-as-draftset-owner}
 
  :drafter.feature.draftset.options/handler {:drafter/backend #ig/ref :drafter/backend
@@ -71,19 +73,24 @@
                                               :timeout-fn #ig/ref [:drafter.timeouts/timeout-query :drafter/draftset-timeout]}
 
  :drafter.feature.draftset-data.delete/delete-data-handler {:drafter/backend #ig/ref :drafter/backend
-                                                             :wrap-as-draftset-owner #ig/ref :drafter.feature.middleware/wrap-as-draftset-owner}
+                                                            :drafter/global-writes-lock #ig/ref :drafter/global-writes-lock
+                                                            :wrap-as-draftset-owner #ig/ref :drafter.feature.middleware/wrap-as-draftset-owner}
 
  :drafter.feature.draftset-data.delete-by-graph/remove-graph-handler {:drafter/backend #ig/ref :drafter/backend
-                                                              :wrap-as-draftset-owner #ig/ref :drafter.feature.middleware/wrap-as-draftset-owner}
+                                                                      :drafter/global-writes-lock #ig/ref :drafter/global-writes-lock
+                                                                      :wrap-as-draftset-owner #ig/ref :drafter.feature.middleware/wrap-as-draftset-owner}
 
  :drafter.feature.draftset.changes/delete-changes-handler {:drafter/backend #ig/ref :drafter/backend
-                                                                :wrap-as-draftset-owner #ig/ref :drafter.feature.middleware/wrap-as-draftset-owner}
+                                                           :drafter/global-writes-lock #ig/ref :drafter/global-writes-lock
+                                                           :wrap-as-draftset-owner #ig/ref :drafter.feature.middleware/wrap-as-draftset-owner}
 
  :drafter.feature.draftset-data.append/data-handler {:drafter/backend #ig/ref :drafter/backend
+                                                     :drafter/global-writes-lock #ig/ref :drafter/global-writes-lock
                                                      :wrap-as-draftset-owner #ig/ref :drafter.feature.middleware/wrap-as-draftset-owner}
 
  :drafter.feature.draftset-data.append-by-graph/handler {:drafter/backend #ig/ref :drafter/backend
-                                                           :wrap-as-draftset-owner #ig/ref :drafter.feature.middleware/wrap-as-draftset-owner}
+                                                         :drafter/global-writes-lock #ig/ref :drafter/global-writes-lock
+                                                         :wrap-as-draftset-owner #ig/ref :drafter.feature.middleware/wrap-as-draftset-owner}
 
  :drafter.feature.draftset.query/handler {:drafter/backend #ig/ref :drafter/backend
                                           :wrap-as-draftset-owner #ig/ref :drafter.feature.middleware/wrap-as-draftset-owner
@@ -93,13 +100,16 @@
                                             :wrap-as-draftset-owner #ig/ref :drafter.feature.middleware/wrap-as-draftset-owner}
 
  :drafter.feature.draftset.set-metadata/handler {:drafter/backend #ig/ref :drafter/backend
+                                                 :drafter/global-writes-lock #ig/ref :drafter/global-writes-lock
                                                  :wrap-as-draftset-owner #ig/ref :drafter.feature.middleware/wrap-as-draftset-owner}
 
  :drafter.feature.draftset.submit/handler {:drafter/backend #ig/ref :drafter/backend
+                                           :drafter/global-writes-lock #ig/ref :drafter/global-writes-lock
                                            :drafter.user/repo #ig/ref :drafter.user/repo
                                            :wrap-as-draftset-owner #ig/ref :drafter.feature.middleware/wrap-as-draftset-owner}
 
  :drafter.feature.draftset.claim/handler {:wrap-auth #ig/ref :drafter.middleware/wrap-auth
+                                          :drafter/global-writes-lock #ig/ref :drafter/global-writes-lock
                                           :drafter/backend #ig/ref :drafter/backend}
 
  :drafter.feature.users.list/get-users-handler {:wrap-auth #ig/ref :drafter.middleware/wrap-auth
@@ -133,7 +143,7 @@
                        :live-sparql-query-route #ig/ref :drafter.routes.sparql/live-sparql-query-route
                        :draftset-api-routes #ig/ref :drafter.routes/draftsets-api
                        :jobs-status-routes #ig/ref :drafter.routes/jobs-status
-                       }
+                       :drafter/global-writes-lock #ig/ref :drafter/global-writes-lock}
 
 
 


### PR DESCRIPTION
> Why?

 * It wanted doing anyway
 * We need to be able to configure the `.tryLock` timeout to test write-locked responses

> Why pass through a may of `resources` rather than just an extra arg?

The functions using this stuff are/were getting seriously unwieldy in terms of amount of parameters they're taking. Bunching the integrant opts/resources together seems OK.

> Why not do the same thing to all the other things in that namespace that could do with the same treatment.

This was already enough of a wild goose chase all over the code base. I think anything additional would end up being impossible to review, and should be in a different PR if/when we choose to do that.
