### PR TITLE
Send a valid request if optional arg is omitted to `get-draftsets`

### DIFF
--- a/drafter-client/src/drafter_client/client.clj
+++ b/drafter-client/src/drafter_client/client.clj
@@ -140,11 +140,12 @@
 (defn get-draftsets
   "List available draftsets, optionally `:include` either
   `#{:all :owned :claimable}`.
-  Returns all propeties."
+  Returns all properties."
   [client access-token & [include]]
-  (let [include (if (keyword include) (c/name include) include)]
-    (->> (i/get client i/get-draftsets access-token :include include)
-         (map ->draftset))))
+  (let [get-draftsets (partial i/get client i/get-draftsets access-token)
+        include (if (keyword include) (c/name include) include)
+        response (if include (get-draftsets :include include) (get-draftsets))]
+    (map ->draftset response)))
 
 (defn get-draftset [client access-token id]
   (->draftset (i/get client i/get-draftset access-token id)))


### PR DESCRIPTION
Fixes #384. I realized after fixing this that I can just use [`client/draftsets`](https://github.com/Swirrl/drafter/blob/master/drafter-client/src/drafter_client/client.clj#L127), but may as well have `get-draftsets` work without its optional argument.