### PR TITLE
Relax spec for make-repo as spec was too tight when run in muttnik

### DIFF
--- a/drafter-client/src/drafter_client/client/repo.clj
+++ b/drafter-client/src/drafter_client/client/repo.clj
@@ -16,6 +16,9 @@
         {:keys [url query-params headers] :as req}
         (-> (i/set-bearer-token client token)
             (martian/request-for endpoint params))
-        query-params (dissoc query-params :query)]
-    (doto (repo/sparql-repo (str url \? (url/map->query query-params)))
-      (.setAdditionalHttpHeaders (select-keys headers ["Authorization"])))))
+        query-params (dissoc query-params :query)
+        repo (repo/sparql-repo (str url \? (url/map->query query-params)))]
+    (if token
+      (doto repo
+        (.setAdditionalHttpHeaders (select-keys headers ["Authorization"])))
+      repo)))

--- a/drafter-client/src/drafter_client/client/spec.clj
+++ b/drafter-client/src/drafter_client/client/spec.clj
@@ -21,7 +21,7 @@
 (s/def ::role string?)
 (s/def ::email string?)
 (s/def ::user (s/keys :req-un [::role ::email]))
-(s/def ::token string?)
+(s/def ::token (s/nilable string?)) ;; nil implies live
 
 
 (s/fdef repo/make-repo


### PR DESCRIPTION
When running make-repo instrumented with its fdef in muttnik the spec
was found to be too tight.  Muttnik calls make-repo with nil as a
token, and relies on it essentially giving it the public endpoint.