### PR TITLE
Remove horrifically sprawling "pull in half the world" pantomime dep

### DIFF
--- a/drafter/deps.edn
+++ b/drafter/deps.edn
@@ -37,7 +37,7 @@
 
         grafter {:mvn/version "2.1.2"}
 
-        com.novemberain/pantomime {:mvn/version "2.11.0"} ;; mime types
+        org.apache.tika/tika-core {:mvn/version "1.23"} ;; mime types
         org.eclipse.rdf4j/rdf4j-runtime {:mvn/version "2.5.0"
                                          :exclusions [ch.qos.logback/logback-classic]}
 

--- a/drafter/src/drafter/middleware.clj
+++ b/drafter/src/drafter/middleware.clj
@@ -9,10 +9,10 @@
             [drafter.responses :as response]
             [drafter.util :as util]
             [grafter-2.rdf4j.formats :refer [mimetype->rdf-format]]
-            [pantomime.media :refer [media-type-named]]
             [ring.util.request :as request]
             [integrant.core :as ig])
-  (:import java.io.File))
+  (:import java.io.File
+           (org.apache.tika.mime MediaType)))
 
 (defmethod ig/init-key :drafter.middleware/wrap-auth
   [_ {:keys [middleware] :as opts}]
@@ -65,6 +65,10 @@
                   (log/warn "Handling SPARQL POST query with missing content type")
                   (handle (get-in request [:params :query]) "'query' form or query parameter")))
         (response/method-not-allowed-response request-method)))))
+
+(defn media-type-named
+  [^String name]
+  (MediaType/parse name))
 
 (defn require-content-type
   "Wraps a ring handler in one which requires the incoming request has


### PR DESCRIPTION
Apart from the fact that including Pantomime as a dependency drove me crazy in Zib and Grafter because of the gazillion pointless libs it pulled in - it wasted so much time in builds (deps downloading) and massively bloated the resultant JAR. 'twas sooo much better after we ripped it out.

Now Pantomime has popped again in Drafter and is also contributing to bloat and long dependency downloads in Muttnik. Friends don't let friends "do Pantomime", kids.

Just look at the reduction in size of the published Drafter Jar here:

<img width="642" alt="Screen Shot 2019-12-19 at 1 02 16 PM" src="https://user-images.githubusercontent.com/241747/71197571-e6f0ce00-225f-11ea-94f5-e238eba216e0.png">

**47.4 MB of useless crap ~ GONE!!!**

Doesn't that make you feel good!? 😄 

Omni gets will be faster too.

Next time I manually download the Drafter jar via Cyberduck it's going to be so sweet over my tiny telephone line.