### PR TITLE
Add a single extra arity to async client methods to handle opts map

### DIFF
--- a/drafter-client/src/drafter_client/client.clj
+++ b/drafter-client/src/drafter_client/client.clj
@@ -166,21 +166,25 @@
 
 (defn remove-draftset
   "Delete the Draftset and its data"
-  [client access-token draftset & {:keys [metadata]}]
-  (-> client
-      (i/request i/delete-draftset access-token (draftset/id draftset) :metadata metadata)
-      (->async-job)))
+  ([client access-token draftset]
+   (remove-draftset client access-token draftset {}))
+  ([client access-token draftset {:keys [metadata]}]
+   (-> client
+       (i/request i/delete-draftset access-token (draftset/id draftset) {:metadata metadata})
+       (->async-job))))
 
 (defn load-graph
   "Load the graph from live into the Draftset"
-  [client access-token draftset graph & {:keys [metadata]}]
-  (-> client
-      (i/request i/put-draftset-graph
-                 access-token
-                 (draftset/id draftset)
-                 (str graph)
-                 :metadata metadata)
-      (->async-job)))
+  ([client access-token draftset graph]
+   (load-graph client access-token draftset graph {}))
+  ([client access-token draftset graph {:keys [metadata]}]
+   (-> client
+       (i/request i/put-draftset-graph
+                  access-token
+                  (draftset/id draftset)
+                  (str graph)
+                  {:metadata metadata})
+       (->async-job))))
 
 (defn delete-graph
   "Schedules the deletion of the graph from live"
@@ -188,23 +192,27 @@
   (i/request client i/delete-draftset-graph access-token (draftset/id draftset) (str graph)))
 
 (defn delete-quads
-  [client access-token draftset quads & {:keys [metadata]}]
-  (-> client
-      (i/set-content-type "application/n-quads")
-      (i/request i/delete-draftset-data access-token (draftset/id draftset) quads :metadata metadata)
-      (->async-job)))
+  ([client access-token draftset quads]
+   (delete-quads client access-token draftset quads {}))
+  ([client access-token draftset quads {:keys [metadata]}]
+   (-> client
+       (i/set-content-type "application/n-quads")
+       (i/request i/delete-draftset-data access-token (draftset/id draftset) quads {:metadata metadata})
+       (->async-job))))
 
 (defn delete-triples
-  [client access-token draftset graph triples & {:keys [metadata]}]
-  (-> client
-      (i/set-content-type "application/n-triples")
-      (i/request i/delete-draftset-data
-                 access-token
-                 (draftset/id draftset)
-                 triples
-                 :graph graph
-                 :metadata metadata)
-      (->async-job)))
+  ([client access-token draftset graph triples]
+   (delete-triples client access-token draftset graph triples {}))
+  ([client access-token draftset graph triples {:keys [metadata]}]
+   (-> client
+       (i/set-content-type "application/n-triples")
+       (i/request i/delete-draftset-data
+                  access-token
+                  (draftset/id draftset)
+                  triples
+                  {:graph graph
+                   :metadata metadata})
+       (->async-job))))
 
 (defn add-data
   "Append the supplied RDF statements to this Draftset.
@@ -212,18 +220,18 @@
   - `opts` is a map of optional arguments, which may include:
     - `graph`: required if the statements are triples
     - `metadata`: a map with arbitrary keys that will be included on the job for future reference"
-  [client access-token draftset statements & {:keys [graph metadata]}]
-  (let [url (martian/url-for client
-                             :put-draftset-data
-                             {:id (draftset/id draftset)})
-        format (i/get-format statements graph)]
-    (-> (i/append-via-http-stream access-token
-                                  url
-                                  statements
-                                  :graph graph
-                                  :format format
-                                  :metadata metadata)
-        (->async-job))))
+  ([client access-token draftset statements]
+   (add-data client access-token draftset statements {}))
+  ([client access-token draftset statements opts]
+   (let [url (martian/url-for client
+                              :put-draftset-data
+                              {:id (draftset/id draftset)})
+         format (i/get-format statements (opts :graph))]
+     (-> (i/append-via-http-stream access-token
+                                   url
+                                   statements
+                                   (assoc opts :format format))
+         (->async-job)))))
 
 (defn add
   "Append the supplied RDF statements to this Draftset.
@@ -232,7 +240,7 @@
   ([client access-token draftset quads]
    (add-data client access-token draftset quads))
   ([client access-token draftset graph triples]
-   (add-data client access-token draftset triples :graph graph)))
+   (add-data client access-token draftset triples {:graph graph})))
 
 (defn add-in-batches
   "Append the supplied RDF data to this Draftset in batches"
@@ -250,10 +258,12 @@
 
 (defn publish
   "Publish the Draftset to live"
-  [client access-token draftset & {:keys [metadata]}]
-  (-> client
-      (i/request i/publish-draftset access-token (draftset/id draftset) :metadata metadata)
-      (->async-job)))
+  ([client access-token draftset]
+   (publish client access-token draftset {}))
+  ([client access-token draftset {:keys [metadata]}]
+   (-> client
+       (i/request i/publish-draftset access-token (draftset/id draftset) {:metadata metadata})
+       (->async-job))))
 
 (defn get
   "Access the quads inside this Draftset"

--- a/drafter-client/src/drafter_client/client/impl.clj
+++ b/drafter-client/src/drafter_client/client/impl.clj
@@ -63,7 +63,7 @@
 
 (defn delete-draftset
   "Delete the Draftset and its data"
-  [client id & {:keys [metadata]}]
+  [client id {:keys [metadata]}]
   (martian/response-for client
                         :delete-draftset
                         (cond-> {:id id}
@@ -81,7 +81,7 @@
 (defn delete-draftset-data
   "Remove the supplied RDF data from this Draftset. Opts may include `graph` if the statements
   to be deleted are triples and `metadata`, which will be stored on the job for future reference."
-  [client id data & {:keys [metadata] :as opts}]
+  [client id data {:keys [metadata] :as opts}]
   (martian/response-for
    client
    :delete-draftset-data
@@ -192,7 +192,7 @@
 
 (defn publish-draftset
   "Publish the specified Draftset"
-  [client id & {:keys [metadata]}]
+  [client id {:keys [metadata]}]
   (martian/response-for client
                         :publish-draftset
                         (cond-> {:id id}
@@ -224,7 +224,7 @@
 (defn append-via-http-stream
   "Write statements (quads, triples, File, InputStream) to a URL, as a
   an input stream by virtue of an HTTP PUT"
-  [access-token url statements & {:keys [graph format metadata] :as _opts}]
+  [access-token url statements {:keys [graph format metadata] :as opts}]
   (let [{input-stream :input worker :worker}
         (if (some #(instance? % statements) [InputStream File])
           {:input statements}
@@ -247,7 +247,7 @@
 
 (defn put-draftset-graph
   "Copy a graph from live into this Draftset"
-  [client id graph & {:keys [metadata]}]
+  [client id graph {:keys [metadata]}]
   (martian/response-for
    client
    :put-draftset-graph

--- a/drafter-client/test/drafter_client/client_test.clj
+++ b/drafter-client/test/drafter_client/client_test.clj
@@ -241,14 +241,14 @@
         name "Draftset adding"
         description "Testing adding things, and reading them"
         triples (test-triples)]
-    (t/testing "Adding triples to a draft set"
+    (testing "Adding triples to a draft set"
       (let [graph (URI. "http://test.graph.com/triple-graph")
             draftset (sut/new-draftset client token name description)
-            _ (sut/add-data-sync client token draftset triples :graph graph)
+            _ (sut/add-data-sync client token draftset triples {:graph graph})
             triples* (sut/get client token draftset graph)]
         (t/is (= (set triples) (set triples*)))))
 
-    (t/testing "Adding quads to a draft set"
+    (testing "Adding quads to a draft set"
       (let [graph (URI. "http://test.graph.com/vanilla-quad-graph")
             draftset (sut/new-draftset client token name description)
             quads (map #(assoc % :c graph) (drop 97 triples))
@@ -259,17 +259,18 @@
     (testing "Custom metadata gets passed on to job"
       (let [graph (URI. "http://test.graph.com/triple-graph")
             draftset (sut/new-draftset client token name description)
-            result (sut/add-data client token draftset triples :graph graph :metadata {:title "Custom job title"})
+            result (sut/add-data client token draftset triples {:graph graph
+                                                                :metadata {:title "Custom job title"}})
             job (sut/job client token (:job-id result))]
         (is (= #{:title :draftset :operation} (-> job :metadata keys set)))
         (is (= "Custom job title" (-> job :metadata :title)))
         ;; wait for this so it doesn't interfere with subsequent tests
         (sut/wait! client token result)))
 
-    (t/testing "it silently ignores metadata that's not an object"
+    (testing "it silently ignores metadata that's not an object"
       (let [graph (URI. "http://test.graph.com/triple-graph")
             draftset (sut/new-draftset client token name description)
-            result (sut/add-data client token draftset triples :graph graph :metadata "not an object")
+            result (sut/add-data client token draftset triples {:graph graph :metadata "not an object"})
             job (sut/job client token (:job-id result))]
         (is (= #{:draftset :operation} (-> job :metadata keys set)))
         (sut/wait! client token result)))))
@@ -291,7 +292,7 @@
         (t/is (= (set expected-triples) (set triples*)))))
 
     (t/testing "Deleting triples with metadata"
-      (let [result (sut/delete-triples client token draftset graph [y-triple] :metadata {:title "Custom job title"})
+      (let [result (sut/delete-triples client token draftset graph [y-triple] {:metadata {:title "Custom job title"}})
             job (sut/job client token (:job-id result))]
         (is (= #{:title :draftset :operation} (-> job :metadata keys set)))
         (is (= "Custom job title" (-> job :metadata :title)))
@@ -302,7 +303,7 @@
                             (URI. "http://x.com/p")
                             (URI. "http://x.com/o")
                             (URI. "http://x.com/g"))
-            result (sut/delete-quads client token draftset [quad] :metadata {:title "Custom job title"})
+            result (sut/delete-quads client token draftset [quad] {:metadata {:title "Custom job title"}})
             job (sut/job client token (:job-id result))]
         (is (= #{:title :draftset :operation} (-> job :metadata keys set)))
         (is (= "Custom job title" (-> job :metadata :title)))
@@ -380,9 +381,9 @@
             draftset (sut/new-draftset client token name description)]
         (sut/add-sync client token draftset quads)
 
-        (let [result (sut/publish client token draftset :metadata {:title "Custom job title"
-                                                                   :multiword-key "Key"
-                                                                   :$-9%&*-> "weird key"})
+        (let [result (sut/publish client token draftset {:metadata {:title "Custom job title"
+                                                                    :multiword-key "Key"
+                                                                    :$-9%&*-> "weird key"}})
               job (sut/job client token (:job-id result))]
           (is (= #{:title :draftset :operation :multiword-key :$-9%&*->}
                  (-> job :metadata keys set)))
@@ -424,7 +425,7 @@
             _ (sut/add-sync client token draftset-1 quads)
             _ (sut/publish-sync client token draftset-1)
             draftset-2 (sut/new-draftset client token name description)
-            result (sut/load-graph client token draftset-2 graph :metadata {:title "Custom job title"})
+            result (sut/load-graph client token draftset-2 graph {:metadata {:title "Custom job title"}})
             job (sut/job client token (:job-id result))]
         (is (= #{:title :draftset :operation} (-> job :metadata keys set)))
         (is (= "Custom job title" (-> job :metadata :title)))
@@ -435,7 +436,7 @@
     (let [client (drafter-client)
           token (auth-util/system-token)
           draftset (sut/new-draftset client token "Test" "Delete me")
-          result (sut/remove-draftset client token draftset :metadata {:title "Custom job title"})
+          result (sut/remove-draftset client token draftset {:metadata {:title "Custom job title"}})
           job (sut/job client token (:job-id result))]
       (is (= #{:title :draftset :operation} (-> job :metadata keys set)))
       (is (= "Custom job title" (-> job :metadata :title)))


### PR DESCRIPTION
These are some minor changes to the async client functions to clean up a clojure antipattern (described [here](https://swirrl.slack.com/archives/C029401RS/p1578682338002300), introduced in #396) before it spreads around to multiple other places consuming the current inferior API. Muttnik will need to be updated to use this version. I'm not sure whether anyone else has started using the in-between version of drafter, but I don't think so.