### PR TITLE
Use job status API to -sync async jobs

### DIFF
--- a/drafter-client/src/drafter_client/client_spec.clj
+++ b/drafter-client/src/drafter_client/client_spec.clj
@@ -1,0 +1,77 @@
+(ns drafter-client.client-spec
+  (:require [clj-time.coerce :refer [from-long]]
+            [drafter-client.client :as client]
+            [drafter-client.client.impl :as i]
+            [drafter.async.spec :as drafter]
+            [clojure.spec.alpha :as s]
+            [clojure.spec.gen.alpha :as gen])
+  (:import drafter_client.client.AsyncJob))
+
+(def date-time?
+  (s/with-gen (partial instance? org.joda.time.DateTime)
+    (fn [] (gen/fmap from-long (s/gen int?)))))
+
+(s/def ::draftset-id (s/nilable uuid?))
+(s/def ::start-time date-time?)
+(s/def ::finish-time (s/nilable date-time?))
+
+(s/def ::job
+  (s/keys :req-un [::drafter/id ::drafter/user-id ::drafter/status
+                   ::drafter/priority
+                   ::start-time ::finish-time]
+          :opt-un [::draftset-id ::drafter/draft-graph-id ::drafter/metadata]))
+
+
+(s/def ::type #{"ok" "error" "not-found"})
+(s/def :ok/type #{"ok"})
+(s/def :error/type #{"error"})
+(s/def :not-found/type #{"not-found"})
+(s/def ::details map?)
+(s/def ::job-id uuid?)
+(s/def ::restart-id uuid?)
+(s/def ::message string?)
+(s/def ::error-class string?)
+
+(s/def ::AsyncJob (s/and #(instance? AsyncJob %)
+                         (s/keys :req-un [::job-id ::restart-id])))
+
+(s/fdef client/job-succeeded? :args (s/cat :job-state ::job) :ret boolean?)
+
+(s/fdef client/job-failed? :args (s/cat :job-state ::job) :ret boolean?)
+
+(s/fdef client/job-complete? :args (s/cat :job-state ::job) :ret boolean?)
+
+(s/fdef client/job-in-progress? :args (s/cat :job-state ::job) :ret boolean?)
+
+(s/fdef client/refresh-job
+  :args (s/cat :client any? :access-token any? :job ::AsyncJob)
+  :ret ::job)
+
+(s/def ::JobSucceededResult (s/nilable map?))
+(s/def ::JobFailedResult client/exception?)
+(s/def ::JobResult (s/or :succeeded ::JobSucceededResult :failed ::JobFailedResult))
+
+(s/fdef client/job-status
+  :args (s/cat :job ::AsyncJob :job-state ::job)
+  :ret (s/or :result ::JobResult :pending #{::pending}))
+
+(s/fdef client/wait-result!
+  :args (s/cat :client ::i/DrafterClient :access-token ::i/AccessToken :job ::AsyncJob)
+  :ret ::JobResult)
+
+(s/fdef client/wait-results!
+  :args (s/cat :client ::i/DrafterClient :access-token ::i/AccessToken :jobs (s/coll-of ::AsyncJob))
+  :ret (s/coll-of ::JobResult))
+
+(s/fdef client/wait!
+  :args (s/cat :client ::i/DrafterClient :access-token ::i/AccessToken :job ::AsyncJob)
+  :ret ::JobSucceededResult)
+
+(s/fdef client/wait-nil!
+  :args (s/cat :client ::i/DrafterClient :access-token ::i/AccessToken :job ::AsyncJob)
+  :ret nil?)
+
+(s/fdef client/wait-all!
+  :args (s/cat :client ::i/DrafterClient :access-token ::i/AccessToken :jobs (s/coll-of ::AsyncJob))
+  :ret (s/coll-of ::JobSucceededResult)
+  :fn (fn [{ret :ret {jobs :jobs} :args}] (= (count ret) (count jobs))))

--- a/drafter-client/src/drafter_client/triplestore.clj
+++ b/drafter-client/src/drafter_client/triplestore.clj
@@ -300,15 +300,19 @@
   (-> (repository client token context)
       (triplestore)))
 
-(defn m2m-triplestore [client]
+(defn m2m-triplestore [client job-timeout]
   (let [token (:access_token (auth/get-client-id-token client))
         context draftset/live]
-    (-> (repository client token context)
+    (-> client
+        (client/with-job-timeout job-timeout)
+        (repository token context)
         (triplestore))))
 
-(defn mock-m2m-triplestore [client mock-token]
+(defn mock-m2m-triplestore [client mock-token job-timeout]
   (let [context draftset/live]
-    (-> (repository client mock-token context)
+    (-> client
+        (client/with-job-timeout job-timeout)
+        (repository mock-token context)
         (triplestore))))
 
 (defmethod ig/init-key :drafter-client.triplestore/auth-code-triplestore
@@ -317,12 +321,12 @@
     (auth-code-triplestore client token draft)))
 
 (defmethod ig/init-key :drafter-client.triplestore/m2m-triplestore
-  [_ {:keys [client]}]
-  (m2m-triplestore client))
+  [_ {:keys [client job-timeout] :or {job-timeout ##Inf}}]
+  (m2m-triplestore client job-timeout))
 
 (defmethod ig/init-key :drafter-client.triplestore/mock-m2m-triplestore
-  [_ {:keys [client token]}]
-  (mock-m2m-triplestore client token))
+  [_ {:keys [client token job-timeout] :or {job-timeout ##Inf}}]
+  (mock-m2m-triplestore client token job-timeout))
 
 (defmethod ig/halt-key! :drafter-client.triplestore/auth-code-triplestore
   [_ triplestore]


### PR DESCRIPTION
Uses the `/job/:id` route to determine a job's status, rather than trying to infer it's status via the `/finish-jobs/:id` route.

I don't think we need to care now if `drafter-restarted?` as we can determine what happened.

- if a job returns `:pending` it's pending
- if a job returns `:complete` it's complete
- if a job was successfully submitted and is now not found, drafter restarted
- otherwise the job was never submitted

Fixes: #349 
