### PR TITLE
Bump stardog dependency to omni package 7.3.2-1.0

### DIFF
--- a/dependencies-mongo-auth.edn
+++ b/dependencies-mongo-auth.edn
@@ -1,3 +1,3 @@
-{"stardog" "7.3.1-1.0" ;; NOTE: also update this in dependencies.edn
+{"stardog" "7.3.2-1.0" ;; NOTE: also update this in dependencies.edn
  "mongodb" "3.2"
  "server-ssl" "1.0"}

--- a/dependencies.edn
+++ b/dependencies.edn
@@ -1,3 +1,3 @@
 ;; note you should also edit dependencies-mongo-auth (which is used for the tests) or if you want to install mongo (e.g. for pmd3)
-{"stardog" "7.3.1-1.0" ;; NOTE: also update this in dependencies-mongo-auth.edn
+{"stardog" "7.3.2-1.0" ;; NOTE: also update this in dependencies-mongo-auth.edn
  "server-ssl" "1.0"}


### PR DESCRIPTION
- Bump Stardog to 7.2.1
- Still on JDK 8
- Note prior to merging this we should test stardog 7.2.1 against ONS/COGS data on a staging server
