### PR TITLE
Remove clj-logging-config, lib-swirrl-server

### DIFF
--- a/drafter/deps.edn
+++ b/drafter/deps.edn
@@ -38,14 +38,17 @@
         grafter/grafter {:mvn/version "2.1.2"}
 
         org.apache.tika/tika-core {:mvn/version "1.23"} ;; mime types
-        org.eclipse.rdf4j/rdf4j-runtime {:mvn/version "2.5.0"
+        org.eclipse.rdf4j/rdf4j-runtime {:mvn/version "3.0.0"
                                          :exclusions [ch.qos.logback/logback-classic]}
 
 
         grafter/url {:mvn/version "0.2.5"}
 
         lib-noir/lib-noir {:mvn/version "0.9.9"
-                  :exclusions [compojure org.clojure/java.classpath org.clojure/tools.reader org.clojure/java.classpath]}
+                           :exclusions [compojure/compojure
+                                        org.clojure/java.classpath
+                                        org.clojure/tools.reader
+                                        org.clojure/java.classpath]}
         me.raynes/fs {:mvn/version "1.4.6"} ;; filesystem utils
 
         metosin/ring-swagger-ui {:mvn/version "3.20.1"}
@@ -62,7 +65,15 @@
 
         org.mindrot/jbcrypt {:mvn/version "0.4"}
 
-        org.slf4j/slf4j-log4j12 {:mvn/version "1.7.26" :exclusions [log4j org.slf4j/slf4j-api]}
+        org.clojure/tools.logging {:mvn/version "0.5.0"}
+        org.apache.logging.log4j/log4j-api {:mvn/version "2.11.1"} ; Import log4j2 as the logging backend
+        org.apache.logging.log4j/log4j-core {:mvn/version "2.11.1"} ; Import log4j2 as the logging backend
+        org.apache.logging.log4j/log4j-slf4j-impl {:mvn/version "2.11.1"} ; Redirect all SLF4J logs over the log4j2 backend
+
+        org.slf4j/log4j-over-slf4j {:mvn/version "1.7.25"} ; redirect log4j 1.x logs
+        org.slf4j/jcl-over-slf4j {:mvn/version "1.7.25"} ; redirect commons logging
+        org.slf4j/jul-to-slf4j {:mvn/version "1.7.25"}
+
         prismatic/schema {:mvn/version "1.1.10"}
 
         ring-middleware-format/ring-middleware-format {:mvn/version "0.7.4"}
@@ -72,13 +83,14 @@
         ring/ring-core {:mvn/version "1.7.1"}
         ring-cors/ring-cors {:mvn/version "0.1.13"}
 
-        swirrl/lib-swirrl-server {:mvn/version "0.6.3" :exclusions [clout org.clojure/java.classpath]}
         wrap-verbs/wrap-verbs {:mvn/version "0.1.1"}
 
         com.auth0/jwks-rsa {:mvn/version "0.8.1"}
         com.auth0/java-jwt {:mvn/version "3.8.0"}
         martian/martian {:mvn/version "0.1.10"}
-        martian-clj-http/martian-clj-http {:mvn/version "0.1.10" :exclusions [clj-http]}
+        martian-clj-http/martian-clj-http {:mvn/version "0.1.10"
+                                           :exclusions [clj-http/clj-http]}
+        medley/medley {:mvn/version "1.3.0"}
         clj-http/clj-http {:mvn/version "3.10.0"}
         swirrl/auth0 {:git/url "git@github.com:Swirrl/swirrl-auth0"
                       :sha "11fbe37324ab238752502f275d3a321fd012a65b"}

--- a/drafter/resources/log4j2.xml
+++ b/drafter/resources/log4j2.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Watch file for changes every 10 seconds -->
+<Configuration status="info" monitorInterval="10">
+
+    <Properties>
+        <Property name="log-path">logs</Property>
+    </Properties>
+
+    <Appenders>
+        <RollingFile name="file-log" fileName="${log-path}/drafter.log"
+                     filePattern="${log-path}/drafter-%d{yyyy-MM-dd}-%i.log">
+            <PatternLayout>
+                <pattern>%d{ISO8601} %-5p %20.20c{1} %12X{user} %12X{jobId} %12X{reqId} :: %m%n</pattern>
+            </PatternLayout>
+            <Policies>
+                <TimeBasedTriggeringPolicy interval="1" modulate="true"/>
+                <SizeBasedTriggeringPolicy size="100 MB" />
+            </Policies>
+        </RollingFile>
+
+        <Console name="console" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{ISO8601} %-5p %20.20c{1} %12X{user} %12X{jobId} %12X{reqId} :: %m%n"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Root level="info" additivity="false">
+            <appender-ref ref="console" level="warn"/> <!-- only log warnings and worse to REPL -->
+            <appender-ref ref="file-log" level="info"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/drafter/src/drafter/async/jobs.clj
+++ b/drafter/src/drafter/async/jobs.clj
@@ -1,16 +1,16 @@
 (ns drafter.async.jobs
-  (:require [compojure.core :refer [context GET routes]]
+  (:require [clj-time.coerce :refer [from-long]]
+            [clj-time.format :refer [formatters unparse]]
             [clojure.spec.alpha :as s]
-            [clj-logging-config.log4j :as l4j]
+            [compojure.core :refer [context GET routes]]
             [drafter.async.responses :as r]
             [drafter.async.spec :as spec]
-            [integrant.core :as ig]
-            [clj-time.coerce :refer [to-date from-long]]
-            [clj-time.format :refer [formatters unparse]]
-            [drafter.draftset :as ds])
-  (:import (java.util UUID)
-           (clojure.lang ExceptionInfo)
-           (org.apache.log4j MDC)))
+            [drafter.draftset :as ds]
+            [drafter.logging :refer [with-logging-context]]
+            [integrant.core :as ig])
+  (:import clojure.lang.ExceptionInfo
+           java.util.UUID
+           org.apache.log4j.MDC))
 
 (defrecord Job [id
                 user-id
@@ -83,7 +83,7 @@
   [f]
   (let [request-id (MDC/get "reqId")] ;; copy reqId off calling thread
     (fn [{job-id :id :as job}]
-      (l4j/with-logging-context {:jobId (str "job-" (.substring (str job-id) 0 8))
+      (with-logging-context {:jobId (str "job-" (.substring (str job-id) 0 8))
                                  :reqId request-id}
         (f job)))))
 

--- a/drafter/src/drafter/backend/draftset/draft_management.clj
+++ b/drafter/src/drafter/backend/draftset/draft_management.clj
@@ -12,7 +12,6 @@
             [grafter.vocabularies.dcterms :refer [dcterms:issued dcterms:modified]]
             [grafter.vocabularies.rdf :refer :all]
             [schema.core :as s]
-            [swirrl-server.errors :refer [ex-swirrl]]
             [grafter-2.rdf4j.io :as rio])
   (:import java.net.URI
            [java.util Date UUID Calendar]
@@ -339,8 +338,8 @@
 
       (let [live-graphs (map :live results)]
         (when (has-duplicates? live-graphs)
-          (throw (ex-swirrl :multiple-drafts-error
-                            "Multiple draft graphs were supplied referencing the same live graph.")))
+          (throw (ex-info "Multiple draft graphs were supplied referencing the same live graph."
+                          {:error :multiple-drafts-error})))
 
         (zipmap live-graphs
                 (map :draft results))))))

--- a/drafter/src/drafter/errors.clj
+++ b/drafter/src/drafter/errors.clj
@@ -3,14 +3,55 @@
   across all routes into Ring JSON error responses, according to our
   error object schema (see the lib-swirrl-server project.).
 
-NOTE:
+  NOTE:
 
-More localised errors are probably better handled within specific routes, as
-these handlers dispatched indiscriminantly on anything bubbling up from the call
-stack of any route - hence you may need to be careful about being
-overly-specific in your interpretation of the error."
-  (:require [drafter.async.responses :as r]
-            [swirrl-server.errors :refer [encode-error]]))
+  More localised errors are probably better handled within specific routes, as
+  these handlers dispatched indiscriminantly on anything bubbling up from the call
+  stack of any route - hence you may need to be careful about being
+  overly-specific in your interpretation of the error."
+  (:require [clojure.tools.logging :as log]
+            [drafter.async.responses :as r]
+            [schema.core :as s]))
+
+(defmulti encode-error
+  "Convert an Exception into an appropriate API error response object.
+  Dispatches on either the exceptions class or if it's a
+  clojure.lang.ExceptionInfo the value of its :error key."
+  (s/fn [err :- (s/either Throwable {s/Any s/Any})]
+    (cond
+      (instance? clojure.lang.ExceptionInfo err) (if-let [error-type (-> err ex-data :error)]
+                                                   error-type
+                                                   (class err))
+      (instance? Exception err) (class err))))
+
+(defmethod encode-error Throwable [ex]
+  ;; The generic catch any possible exception case
+  (r/error-response 500 :unknown-error (.getMessage ex)))
+
+(defmethod encode-error clojure.lang.ExceptionInfo [ex]
+  ;; Handle ex-info errors that don't define one of our :error keys
+  (r/error-response 500 :unknown-error (.getMessage ex)))
+
+(defmethod encode-error :default [ex]
+  (if (instance? clojure.lang.ExceptionInfo ex)
+    (let [error-type (:error (ex-data ex))]
+      (assert error-type "Because the defmulti dispatches clojure.lang.ExceptionInfo's as :keywords we should never have a nil error-type here" )
+      (r/error-response 500 error-type (.getMessage ex)))
+    (r/error-response 500 :unhandled-error (str "Unknown error: " (.getMessage ex)))))
+
+(defn wrap-encode-errors
+  "A ring middleware to handle and render Exceptions and ex-swirrl
+  style errors.  You should mix this into your middlewares as high up
+  as you can.
+  We don't currently do any content negotiation here, so this will
+  return all exceptions as JSON."
+  [handler]
+  (fn [req]
+    (try
+      (handler req)
+      (catch Throwable ex
+        (log/error ex "There was an unknown error.  Returning 500")
+        (encode-error ex)))))
 
 (defmethod encode-error org.eclipse.rdf4j.query.QueryEvaluationException [ex]
   ;; This exception should also be caught in specific routes concerned with

--- a/drafter/src/drafter/feature/draftset/query.clj
+++ b/drafter/src/drafter/feature/draftset/query.clj
@@ -4,7 +4,7 @@
             [drafter.routes.draftsets-api :refer [parse-union-with-live-handler]]
             [drafter.rdf.sparql-protocol :as sp :refer [sparql-protocol-handler]]
             [ring.middleware.cors :as cors]
-            [swirrl-server.errors :refer [wrap-encode-errors]]
+            [drafter.errors :refer [wrap-encode-errors]]
             [integrant.core :as ig]))
 
 (defn handler

--- a/drafter/src/drafter/handler.clj
+++ b/drafter/src/drafter/handler.clj
@@ -20,8 +20,8 @@
             [ring.middleware.file-info :refer [wrap-file-info]]
             [ring.middleware.resource :refer [wrap-resource]]
             [ring.middleware.verbs :refer [wrap-verbs]]
-            [swirrl-server.errors :refer [wrap-encode-errors]]
-            [swirrl-server.middleware.log-request :refer [log-request]]))
+            [drafter.errors :refer [wrap-encode-errors]]
+            [drafter.logging :refer [log-request]]))
 
 (defroutes app-routes
   (GET "/swagger/swagger.json" []

--- a/drafter/src/drafter/logging.clj
+++ b/drafter/src/drafter/logging.clj
@@ -1,41 +1,71 @@
 (ns drafter.logging
   (:require [clojure.tools.logging :as log]
             [integrant.core :as ig]
-            [clj-logging-config.log4j]
-            [clojure.java.io :as io]))
+            [clojure.java.io :as io])
+  (:import org.apache.logging.log4j.ThreadContext
+           java.util.UUID))
 
+;; Modified from withdrawn library:
+;; https://github.com/malcolmsparks/clj-logging-config/blob/master/src/main/clojure/clj_logging_config/log4j.clj
+(defmacro with-logging-context [x & body]
+  `(let [x# ~x
+         ctx# (into {} (ThreadContext/getContext))]
+     (try
+       (if (map? x#)
+         (run! (fn [[k# v#]]
+                 (when-not (nil? v#)
+                   (ThreadContext/put (name k#) (str v#)))) x#)
+         (ThreadContext/push (str x#)))
+       ~@body
+       (finally
+        (if (map? x#)
+          (run! (fn [[k# v#]]
+                  (ThreadContext/remove (name k#))
+                  (when-let [old# (get ctx# (name k#))]
+                    (ThreadContext/put (name k#) (str old#)))) x#)
+          (ThreadContext/pop))))))
 
-(defn- import-logging! []
-  ;; Note that though the classes and requires below aren't used in this
-  ;; namespace they are needed by the log-config file which is loaded
-  ;; from here.
-  (import '[org.apache.log4j ConsoleAppender DailyRollingFileAppender RollingFileAppender EnhancedPatternLayout PatternLayout SimpleLayout]
-          '[org.apache.log4j.helpers DateLayout]
-          '[java.util UUID])
+(defn log-request
+  "A ring middleware that logs HTTP requests and responses in the
+  Swirrl house-style.  It runs each request in a log4j MDC scope and
+  sets a request id to every request.  Additionally it logs the
+  time spent serving each request/response.
+  Takes an optional map of parameters to scrub from logs, e.g. a map
+  like this:
+  {:param-a \"scrubbed\"
+   :param-b \"hidden\"}
+  Will ensure that :param-a is logged as \"scrubbed\" by this
+  middleware and that the value at :param-b is replaced by the string
+  \"hidden\"."
+  ([handler]
+   (log-request handler {}))
+  ([handler scrub-map]
+   (let [scrub (fn [acc [k v]]
+                 (if (acc k)
+                   (assoc acc k v)
+                   acc))]
+     (fn [req]
+       (let [start-time (System/currentTimeMillis)]
+         (with-logging-context {:reqId (str "req-" (-> (UUID/randomUUID) str (.substring 0 8)))
+                                    :start-time start-time}
+           (let [logable-params (reduce scrub
+                                        (:params req {})
+                                        scrub-map)]
 
-  (require '[clj-logging-config.log4j]
-           'drafter.errors))
+             (log/info "REQUEST" (:uri req) (-> req :headers (get "accept")) logable-params))
+           (let [resp (handler req)
+                 headers-time (- (System/currentTimeMillis) start-time)]
+             (if (instance? java.io.InputStream (:body resp))
+               (log/info "RESPONSE" (:status resp) "headers sent after" (str headers-time "ms") "streaming body...")
+               (log/info "RESPONSE " (:status resp) "finished.  It took" (str headers-time "ms") "to execute"))
 
-(defn- load-logging-configuration [config-file]
-  (-> config-file slurp read-string))
-
-(def default-config-resource (io/resource "log-config.edn"))
-
-(defn configure-logging! [config-file]
-  (import-logging!)
-  (binding [*ns* (find-ns 'drafter.logging)]
-    (let [default-config (load-logging-configuration default-config-resource)
-          config-file (when config-file
-                        (load-logging-configuration (io/file config-file)))]
-
-      (let [chosen-config (or config-file default-config)]
-        (eval chosen-config)
-        (log/debug "Loaded logging config" chosen-config))))
-  {:config config-file})
-
+             resp)))))))
 
 (defmethod ig/init-key :drafter/logging [_ {:keys [config]}]
-  (configure-logging! config))
+  ;; (configure-logging! config)
+  ;; Nothing to do here?
+  )
 
 (defmethod ig/halt-key! :drafter/logging [_ _]
-  (clj-logging-config.log4j/reset-logging!))
+  ;; (clj-logging-config.log4j/reset-logging!)
+  )

--- a/drafter/src/drafter/responses.clj
+++ b/drafter/src/drafter/responses.clj
@@ -1,11 +1,11 @@
 (ns drafter.responses
   (:require [clojure.string :refer [upper-case]]
             [clojure.tools.logging :as log]
-            [drafter.rdf.draftset-management.job-util :refer [failed-job-result?]]
-            [drafter.write-scheduler :as writes :refer [exec-sync-job!]]
             [drafter.async.jobs :as jobs]
             [drafter.async.responses :as r :refer [submitted-job-response]]
-            [swirrl-server.errors :refer [encode-error]]))
+            [drafter.errors :refer [encode-error]]
+            [drafter.rdf.draftset-management.job-util :refer [failed-job-result?]]
+            [drafter.write-scheduler :as writes :refer [exec-sync-job!]]))
 
 (defmethod encode-error :writes-temporarily-disabled [ex]
   (r/error-response 503 ex))

--- a/drafter/src/drafter/routes.clj
+++ b/drafter/src/drafter/routes.clj
@@ -10,18 +10,15 @@
 
   Also takes a :context \"/path\" option.
   "
-  (:require [clj-logging-config.log4j :as l4j]
+  (:require [clojure.spec.alpha :as s]
             [compojure.core :as compojure]
-            [integrant.core :as ig]
-            [clojure.spec.alpha :as s]
-            [clojure.string :as string]))
+            [drafter.logging :refer [with-logging-context]]
+            [integrant.core :as ig]))
 
 (defn make-route [method route handler-fn]
   (compojure/make-route method route
                         (fn [req]
-                          (l4j/with-logging-context
-                            {:method method
-                             :route route}
+                          (with-logging-context {:method method :route route}
                             (handler-fn req)))))
 
 (defn attach-route [[method route handler]]

--- a/drafter/src/drafter/routes/sparql.clj
+++ b/drafter/src/drafter/routes/sparql.clj
@@ -1,11 +1,8 @@
 (ns drafter.routes.sparql
-  (:require [compojure.core :refer [make-route]]
-            [drafter.rdf
-             [sparql-protocol :refer [sparql-end-point] :as sp]]
+  (:require [clojure.spec.alpha :as s]
+            [drafter.errors :refer [wrap-encode-errors]]
+            [drafter.rdf.sparql-protocol :as sp :refer [sparql-end-point]]
             [integrant.core :as ig]
-            [clojure.spec.alpha :as s]
-            [drafter.timeouts :as timeouts]
-            [swirrl-server.errors :refer [wrap-encode-errors]]
             [ring.middleware.cors :as cors]))
 
 ;; TODO: Remove this namespace as all it really adds to

--- a/drafter/test/drafter/routes/status_test.clj
+++ b/drafter/test/drafter/routes/status_test.clj
@@ -4,9 +4,7 @@
             [drafter.routes.status :refer :all]
             [drafter.test-common :as tc]
             [ring.mock.request :refer :all]
-            [schema.core :as s]
-            [schema.test :refer [validate-schemas]]
-            [swirrl-server.async.status-routes :refer [JobNotFinishedResponse]])
+            [schema.test :refer [validate-schemas]])
   (:import java.util.concurrent.locks.ReentrantLock
            java.util.UUID))
 


### PR DESCRIPTION
clj-logging-config is deprecated, and relies on an insecure log4j 1.2
lib-swirrl-server pulls clj-logging-config, and is not used that much
anyway.

Tweaks to dependencies as latest clj/clojure tooling unhides dependency
conflicts in log4j and rdf4j.