### PR TITLE
Validate quads, disallowing BNodes as graph ID

### DIFF
--- a/drafter/src/drafter/feature/draftset_data/append.clj
+++ b/drafter/src/drafter/feature/draftset_data/append.clj
@@ -78,9 +78,15 @@
       statements
       (map #(util/make-quad-statement % graph) statements))))
 
+(defn- validate-quad [quad]
+  (let [g (pr/context quad)]
+    (if (pr/blank-node? g)
+      (throw (ex-info "Blank node as graph ID" {:type :error}))
+      quad)))
+
 (defn append-data-to-draftset-job
   [tempfile {:keys [backend] :as resources} user-id {:keys [draftset-id metadata] :as params} clock-fn]
-  (let [quads (get-quads tempfile params)]
+  (let [quads (map validate-quad (get-quads tempfile params))]
     (jobs/make-job user-id
                    :background-write
                    (jobs/job-metadata backend draftset-id 'append-data-to-draftset metadata)

--- a/drafter/test/drafter/feature/draftset/test_helper.clj
+++ b/drafter/test/drafter/feature/draftset/test_helper.clj
@@ -97,7 +97,10 @@
 (defn append-quads-to-draftset-through-api [handler user draftset-location quads]
   (let [request (statements->append-request user draftset-location quads {:format :nq})
         response (handler request)]
-    (tc/await-success (get-in response [:body :finished-job]))))
+    (or (some-> response
+                (get-in [:body :finished-job])
+                (tc/await-success))
+        (throw (ex-info "No job-path present in response" response)))))
 
 (defn make-append-data-to-draftset-request [handler user draftset-location data-file-path]
   (with-open [fs (io/input-stream data-file-path)]


### PR DESCRIPTION
Fixes: #436 