### PR TITLE
Return Swagger UI content directly in page route

### DIFF
--- a/drafter/src/drafter/routes/pages.clj
+++ b/drafter/src/drafter/routes/pages.clj
@@ -4,4 +4,4 @@
 
 (defn pages-routes []
   (routes
-   (GET "/" [] (io/resource "swagger-ui/index.html"))))
+   (GET "/" [] (slurp (io/resource "swagger-ui/index.html")))))


### PR DESCRIPTION
Issue #449 - The swagger UI page route returns a URL to the HTML
page resource. This is rendered as either binary content or a file
depending on the URL scheme within the ring Render protocol. The
resource has a scheme of 'jar' so it treated as binary data and
given a content type of 'application/octet-stream'.

Return the contents of the resource as a string which is given a
text/html content type by the render process.