### PR TITLE
Add example Procfile for running dependencies in development

### DIFF
--- a/drafter/.gitignore
+++ b/drafter/.gitignore
@@ -26,3 +26,4 @@ tmp
 stasher-cache
 env/dev/drafter-local-config.edn
 .cpcache
+Procfile

--- a/drafter/Procfile.example
+++ b/drafter/Procfile.example
@@ -1,0 +1,2 @@
+stardog: trap '../.omni_cache/install/stardog/install/stardog/bin/stardog-admin server stop' EXIT > /dev/null; env STARDOG_HOME=$(pwd)/../.omni_cache/install/stardog/install/stardog-home $(pwd)/../.omni_cache/install/stardog/install/stardog/bin/stardog-admin server start --disable-security --foreground
+mongodb: docker run -p 27017:27017 --rm --name mongodb-dev -v $(pwd)/../.omni_cache/install/mongodb/install/data:/data/db -v $(pwd)/../.omni_cache/install/mongodb/install/dump:/dump mongo:3.2


### PR DESCRIPTION
Issue #461 - Add example Procfile which runs stardog and mongodb
from the local omni cache.