### PR TITLE
Client: Augment `make-repo` to build an update repo for draftsets

### DIFF
--- a/drafter-client/src/drafter_client/client/repo.clj
+++ b/drafter-client/src/drafter_client/client/repo.clj
@@ -2,9 +2,18 @@
   (:require [cemerick.url :as url]
             [drafter-client.client.draftset :as draftset]
             [drafter-client.client.impl :as i]
-            [drafter-client.client.interceptors :as interceptor]
             [grafter-2.rdf4j.repository :as repo]
             [martian.core :as martian]))
+
+(defn- get-query-request
+  "When constructing query and update requests the :query and :update parameters are
+   required on the operation but should not be set in the query parameters for the
+   corresponding query endpoint. Build a request with a dummy value for the specified
+   query parameter and remove it from the output parameters."
+  [martian route-name params query-key]
+  (let [params (assoc params query-key "dummy")
+        request (martian/request-for martian route-name params)]
+    (update request :query-params dissoc query-key)))
 
 (defn make-repo
   "Takes a DrafterClient and returns a grafter sparql-repo on it with
@@ -23,8 +32,7 @@
 
   params   - A map of extra parameters to pass to the endpoint. "
   [client endpoint token params]
-  (let [params (update params :query (fnil identity ""))
-        [query-endpoint-key update-endpoint-key params] (if (draftset/live? endpoint)
+  (let [[query-endpoint-key update-endpoint-key params] (if (draftset/live? endpoint)
                                                           [:get-query-live nil params]
                                                           [:get-query-draftset
                                                            :post-update-draftset
@@ -34,13 +42,11 @@
         {query-url :url
          query-params :query-params
          headers :headers} (-> (i/with-authorization client token)
-                               (martian/request-for query-endpoint-key params))
-
-        {update-url :url} (martian/request-for client update-endpoint-key (assoc params :update "_"))
-        query-params (dissoc query-params :query)
-        sparql-repo (if update-url
-                      (repo/sparql-repo (str query-url \? (url/map->query query-params))
-                                        (str update-url \? (url/map->query query-params)))
+                               (get-query-request query-endpoint-key params :query))
+        sparql-repo (if update-endpoint-key
+                      (let [{update-url :url update-params :query-params} (get-query-request client update-endpoint-key params :update)]
+                        (repo/sparql-repo (str query-url \? (url/map->query query-params))
+                                          (str update-url \? (url/map->query update-params))))
                       (repo/sparql-repo (str query-url \? (url/map->query query-params))))]
     (.setAdditionalHttpHeaders sparql-repo (select-keys headers ["Authorization"]))
     sparql-repo))


### PR DESCRIPTION
During the work for https://github.com/Swirrl/muttnik/pull/887 which calls the new drafter SPARQL update endpoint, it was discovered that `make-repo` only builds query endpoints.

This PR augments `make-repo` to build a query / update SPARQL repo for draftset endpoints.

A copy of this code is currently running within muttnik. This copy will be removed when this PR (or a version of it!) is merged.