### PR TITLE
Add component for managing the creation of draft graphs

### DIFF
--- a/drafter/resources/drafter-base-config.edn
+++ b/drafter/resources/drafter-base-config.edn
@@ -40,7 +40,7 @@
 
  :drafter/backend {:repo #ig/ref :drafter.stasher/repo}
  :drafter/global-writes-lock {:fairness true :time 10 :unit :seconds}
- :drafter/protected-graphs {:graphset #{#regex "http://publishmydata.com/graphs/drafter/.*"}}
+ :drafter.backend.draftset.graphs/manager {:repo #ig/ref :drafter.stasher/repo}
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -84,11 +84,12 @@
 
  :drafter.feature.draftset-data.delete/delete-data-handler {:drafter/backend #ig/ref :drafter/backend
                                                             :drafter/global-writes-lock #ig/ref :drafter/global-writes-lock
-                                                            :drafter/protected-graphs #ig/ref :drafter/protected-graphs
+                                                            :drafter.backend.draftset.graphs/manager #ig/ref :drafter.backend.draftset.graphs/manager
                                                             :wrap-as-draftset-owner #ig/ref :drafter.feature.middleware/wrap-as-draftset-owner}
 
  :drafter.feature.draftset-data.delete-by-graph/remove-graph-handler {:drafter/backend #ig/ref :drafter/backend
                                                                       :drafter/global-writes-lock #ig/ref :drafter/global-writes-lock
+                                                                      :drafter.backend.draftset.graphs/manager #ig/ref :drafter.backend.draftset.graphs/manager
                                                                       :wrap-as-draftset-owner #ig/ref :drafter.feature.middleware/wrap-as-draftset-owner}
 
  :drafter.feature.draftset.changes/delete-changes-handler {:drafter/backend #ig/ref :drafter/backend
@@ -97,11 +98,12 @@
 
  :drafter.feature.draftset-data.append/data-handler {:drafter/backend #ig/ref :drafter/backend
                                                      :drafter/global-writes-lock #ig/ref :drafter/global-writes-lock
-                                                     :drafter/protected-graphs #ig/ref :drafter/protected-graphs
+                                                     :drafter.backend.draftset.graphs/manager #ig/ref :drafter.backend.draftset.graphs/manager
                                                      :wrap-as-draftset-owner #ig/ref :drafter.feature.middleware/wrap-as-draftset-owner}
 
  :drafter.feature.draftset-data.append-by-graph/handler {:drafter/backend #ig/ref :drafter/backend
                                                          :drafter/global-writes-lock #ig/ref :drafter/global-writes-lock
+                                                         :drafter.backend.draftset.graphs/manager #ig/ref :drafter.backend.draftset.graphs/manager
                                                          :wrap-as-draftset-owner #ig/ref :drafter.feature.middleware/wrap-as-draftset-owner}
 
  :drafter.feature.draftset.query/handler {:drafter/backend #ig/ref :drafter/backend
@@ -109,7 +111,7 @@
                                           :timeout-fn #ig/ref [:drafter.timeouts/timeout-query :drafter/draftset-timeout]}
 
  :drafter.feature.draftset.update/handler {:drafter/backend #ig/ref :drafter/backend
-                                           :drafter/protected-graphs #ig/ref :drafter/protected-graphs
+                                           :drafter.backend.draftset.graphs/manager #ig/ref :drafter.backend.draftset.graphs/manager
                                            :wrap-as-draftset-owner #ig/ref :drafter.feature.middleware/wrap-as-draftset-owner
                                            :max-update-size 5000}
 

--- a/drafter/src/drafter/backend/draftset/graphs.clj
+++ b/drafter/src/drafter/backend/draftset/graphs.clj
@@ -1,0 +1,167 @@
+(ns drafter.backend.draftset.graphs
+  (:require [integrant.core :as ig]
+            [grafter.vocabularies.rdf :refer :all]
+            [drafter.rdf.drafter-ontology :refer :all]
+            [drafter.backend.draftset.draft-management :as mgmt]
+            [drafter.rdf.sparql :as sparql]
+            [drafter.draftset :as ds]
+            [drafter.backend.draftset.operations :as dsops]
+            [drafter.util :as util]
+            [grafter.url :as url])
+  (:import [java.util.regex Pattern]
+           [java.net URI]))
+
+(def ^:private default-protected-graphs #{#"http://publishmydata.com/graphs/drafter/.*"})
+
+(defprotocol URIMatcher
+  "Protocol for matching URIs against a specification"
+  (uri-matches? [this uri]))
+
+(extend-protocol URIMatcher
+  Pattern
+  (uri-matches? [this uri]
+    (boolean (re-matches this (str uri))))
+
+  URI
+  (uri-matches? [this uri]
+    (= this uri)))
+
+(defn create-manager
+  "Creates a graph manager with an optional collection of additional protected
+   graph specifications. Each element in the input collection should implement
+   the URIMatcher protocol. A graph is considered to be protected if it matches
+   any of either the default or specified matchers."
+  ([repo] (create-manager repo #{}))
+  ([repo protected-graphs]
+   {:repo repo
+    :protected-graphs (into default-protected-graphs protected-graphs)}))
+
+(defn protected-graph?
+  "Whether the given graph URI is protected"
+  [{:keys [protected-graphs] :as manager} graph-uri]
+  (->> protected-graphs
+       (some (fn [m] (uri-matches? m graph-uri)))
+       (boolean)))
+
+(defn- check-graph-unprotected!
+  "Throws an exception if the given live graph URI represents a protected graph"
+  [manager live-graph-uri]
+  (when (protected-graph? manager live-graph-uri)
+    (throw (ex-info (str "Cannot create draft of protected graph " live-graph-uri)
+                    {:error :protected-graph-modification-error
+                     :graph-uri live-graph-uri}))))
+
+(defn- check-graph-protected!
+  [manager live-graph-uri]
+  (when-not (protected-graph? manager live-graph-uri)
+    (throw (ex-info (format "Expected graph %s to be protected" live-graph-uri)
+                    {:error :protected-graph-confusion
+                     :graph-uri live-graph-uri}))))
+
+(defn- new-managed-graph-statements [graph-uri]
+  (mgmt/to-quads
+    [graph-uri
+     [rdf:a drafter:ManagedGraph]
+     [drafter:isPublic false]]))
+
+(defn new-managed-user-graph-statements
+  "Returns RDF statements representing a new managed user graph. Throws an exception
+   if the URI is not valid for user graphs."
+  [manager graph-uri]
+  (check-graph-unprotected! manager graph-uri)
+  (new-managed-graph-statements graph-uri))
+
+(defn new-draft-user-graph-statements
+  "Returns RDF statements representing a new draft graph for the user graph URI. Throws
+   and exception if the URI is not valid for user graphs."
+  [manager live-graph-uri draft-graph-uri time draftset-uri]
+  (check-graph-unprotected! manager live-graph-uri)
+  (let [live-graph-triples [live-graph-uri
+                            [drafter:hasDraft draft-graph-uri]]
+        draft-graph-triples [draft-graph-uri
+                             [rdf:a drafter:DraftGraph]
+                             [drafter:createdAt time]
+                             [drafter:modifiedAt time]]
+        draft-graph-triples (cond-> draft-graph-triples
+                                    (some? draftset-uri) (conj [drafter:inDraftSet draftset-uri]))]
+    (apply mgmt/to-quads [live-graph-triples draft-graph-triples])))
+
+(defn- ensure-managed-graph
+  "Ensures a managed graph exists for the specified URI. Callers should check the
+   graph URI is a valid user/protected graph as required."
+  [{:keys [repo] :as manager} graph-uri]
+  ;; We only do anything if it's not already a managed graph
+
+  ;; FIXME: Is this a potential race condition? i.e. we check for existence (and it's false) and before executing someone else makes
+  ;; the managed graph(?). Ideally, we'd do this as a single INSERT/WHERE statement.
+  (when-not (mgmt/is-graph-managed? repo graph-uri)
+    (let [managed-graph-quads (new-managed-graph-statements graph-uri)]
+      (sparql/add repo managed-graph-quads)))
+  graph-uri)
+
+(defn ensure-managed-user-graph
+  "Ensures a managed graph exists for the given user graph URI. Throws an exception if
+   the graph needs to be created but is not a valid user graph."
+  [manager graph-uri]
+  (check-graph-unprotected! manager graph-uri)
+  (ensure-managed-graph manager graph-uri))
+
+(defn- draft-graph-statements
+  [live-graph-uri draft-graph-uri time draftset-uri]
+  (let [live-graph-triples [live-graph-uri
+                            [drafter:hasDraft draft-graph-uri]]
+        draft-graph-triples [draft-graph-uri
+                             [rdf:a drafter:DraftGraph]
+                             [drafter:createdAt time]
+                             [drafter:modifiedAt time]
+                             [drafter:inDraftSet draftset-uri]]]
+    (apply mgmt/to-quads [live-graph-triples draft-graph-triples])))
+
+(defn- create-draft-graph
+  "Creates a new draft graph with a unique graph name, expects the
+  live graph to already be created. Returns the URI of the draft that
+  was created."
+  [{:keys [repo] :as manager} draftset-ref live-graph-uri]
+  (let [now (util/get-current-time)
+        draft-graph-uri (mgmt/make-draft-graph-uri)
+        draftset-uri (url/->java-uri draftset-ref)
+        quads (draft-graph-statements live-graph-uri draft-graph-uri now draftset-uri)]
+    (sparql/add repo quads)
+    draft-graph-uri))
+
+(defn create-user-graph-draft
+  "Creates a draft for a user (i.e. not protected) graph URI. Throws an exception
+   if the specified graph URI is protected."
+  [manager draftset-ref user-graph-uri]
+  (ensure-managed-user-graph manager user-graph-uri)
+  (create-draft-graph manager draftset-ref user-graph-uri))
+
+(defn create-protected-graph-draft
+  "Creates a draft for a protected graph URI. Throws an exception if the graph URI
+   is not protected."
+  [manager draftset-ref protected-graph-uri]
+  (check-graph-protected! manager protected-graph-uri)
+  (ensure-managed-graph manager protected-graph-uri)
+  (create-draft-graph manager draftset-ref protected-graph-uri))
+
+(defn delete-user-graph
+  "Marks a user graph for deletion in live by removing its contents within a draft
+   and returns the draft graph URI. If the graph doesn't exist in the draftset an
+   empty draft graph is created for it, publishing the empty graph will then result
+   in a deletion from live. Throws an exception if the graph-uri is not a valid
+   user graph."
+  [{:keys [repo] :as manager} draftset-ref graph-uri]
+  (check-graph-unprotected! manager graph-uri)
+  (when (mgmt/is-graph-managed? repo graph-uri)
+    (let [graph-mapping (dsops/get-draftset-graph-mapping repo draftset-ref)
+          modified-at (util/get-current-time)]
+      (if-let [draft-graph-uri (get graph-mapping graph-uri)]
+        (do
+          (mgmt/delete-graph-contents! repo draft-graph-uri modified-at)
+          (mgmt/unrewrite-draftset! repo {:draftset-uri (ds/->draftset-uri draftset-ref)
+                                          :live-graph-uris [graph-uri]})
+          draft-graph-uri)
+        (create-draft-graph manager draftset-ref graph-uri)))))
+
+(defmethod ig/init-key ::manager [_ {:keys [repo protected-graphs] :as opts}]
+  (create-manager repo protected-graphs))

--- a/drafter/src/drafter/feature/draftset_data/delete_by_graph.clj
+++ b/drafter/src/drafter/feature/draftset_data/delete_by_graph.clj
@@ -8,15 +8,16 @@
             [drafter.routes.draftsets-api
              :refer
              [parse-query-param-flag-handler]]
-            [drafter.util :as util]
+            [drafter.backend.draftset.graphs :as graphs]
             [integrant.core :as ig]
             [ring.util.response :as ring]
             [drafter.requests :as req]))
 
 (defn remove-graph-from-draftset-handler
-  "Remove a supplied graph from the draftset."
-  [{:keys [:drafter/backend :drafter/global-writes-lock wrap-as-draftset-owner]}]
-  (let [resources {:backend backend :global-writes-lock global-writes-lock}]
+  "Ensures a user graph is deleted within a draftset"
+  [{:keys [:drafter/backend :drafter/global-writes-lock wrap-as-draftset-owner] :as opts}]
+  (let [resources {:backend backend :global-writes-lock global-writes-lock}
+        graph-manager (::graphs/manager opts)]
     (wrap-as-draftset-owner
      (parse-query-param-flag-handler
       :silent
@@ -28,14 +29,14 @@
                                  (req/user-id request)
                                  'delete-draftset-graph
                                  draftset-id
-                                 #(dsops/delete-draftset-graph! backend draftset-id graph util/get-current-time)
+                                 #(graphs/delete-user-graph graph-manager draftset-id graph)
                                  #(feat-common/draftset-sync-write-response % backend draftset-id))
            (if silent
              (ring/response (dsops/get-draftset-info backend draftset-id))
              (drafter-response/unprocessable-entity-response (str "Graph not found"))))))))))
 
 (defmethod ig/pre-init-spec :drafter.feature.draftset-data.delete-by-graph/remove-graph-handler [_]
-  (s/keys :req [:drafter/backend :drafter/global-writes-lock]
+  (s/keys :req [:drafter/backend :drafter/global-writes-lock ::graphs/manager]
           :req-un [::wrap-as-draftset-owner]))
 
 (defmethod ig/init-key :drafter.feature.draftset-data.delete-by-graph/remove-graph-handler [_ opts]

--- a/drafter/src/drafter/spec.clj
+++ b/drafter/src/drafter/spec.clj
@@ -1,8 +1,7 @@
 (ns drafter.spec
   (:require [clojure.spec.alpha :as s]
             [drafter.util :as util]
-            [clojure.spec.gen.alpha :as gen]
-            [integrant.core :as ig])
+            [clojure.spec.gen.alpha :as gen])
   (:import [java.net URI]))
 
 (s/def :drafter/URI #(instance? URI %))
@@ -16,15 +15,6 @@
   (s/coll-of (s/or :uri uri?
                    :regex (partial instance? java.util.regex.Pattern))
              :kind set?))
-
-(s/def :drafter/protected-graphs
-  (s/keys :req-un [::graphset]))
-
-(s/def :drafter/union-with-live? boolean?)
-
-(defmethod ig/init-key :drafter/protected-graphs [_ opts]
-  ;; :groan: :duct/const
-  opts)
 
 (def spec-namespaces
   '[drafter.spec

--- a/drafter/src/drafter/util.clj
+++ b/drafter/src/drafter/util.clj
@@ -82,14 +82,6 @@
   [queries]
   (str/join ";\n" queries))
 
-(defmacro conj-if
-  "Returns (conj col x) if test evaluates to true, otherwise returns
-  col."
-  [test col x]
-  `(if ~test
-     (conj ~col ~x)
-     ~col))
-
 (defn- create-partition-batches
   "Given a sequence of batches, creates an equivalence partition by partition-fn within each batch
   and then partitions each equivalence partition by output-batch-size. Processes each batch within

--- a/drafter/test/drafter/backend/draftset/graphs_test.clj
+++ b/drafter/test/drafter/backend/draftset/graphs_test.clj
@@ -1,0 +1,164 @@
+(ns drafter.backend.draftset.graphs-test
+  (:require [drafter.backend.draftset.graphs :refer :all]
+            [clojure.test :as t]
+            [drafter.test-common :as tc]
+            [drafter.backend.draftset.draft-management :as mgmt]
+            [drafter.fixture-data :as fd]
+            [grafter-2.rdf4j.repository :as repo]
+            [drafter.backend.draftset.operations :as dsops]
+            [drafter.user-test :refer [test-editor]]
+            [drafter.test-helpers.draft-management-helpers :as mgmth]
+            [drafter.util :as util]
+            [grafter-2.rdf4j.sparql :as sp]
+            [grafter.url :as url])
+  (:import [java.net URI]))
+
+(t/deftest uri-matches?-test
+  (t/are [matcher uri expected] (= expected (uri-matches? matcher uri))
+    ;;regex
+    #"http://example.com/graphs/.*" (URI. "http://example.com/graphs/test") true
+    #"http://example.com/graphs/.*" (URI. "http://test.com/user") false
+
+    ;;uri
+    (URI. "http://example.com/test") (URI. "http://example.com/test") true
+    (URI. "http://example.com/test") (URI. "http://test.com/uesr") false))
+
+(t/deftest create-manager-test
+  (let [repo (repo/memory-store)]
+    (t/testing "Default protected graphs"
+      (let [manager (create-manager repo)]
+        (t/is (= true (protected-graph? manager mgmt/drafter-state-graph)) "Expected state graph to be protected")))
+
+    (t/testing "Extra protected graphs"
+      (let [protected-graphs [(URI. "http://protected")
+                              (URI. "http://system-graph")]
+            manager (create-manager repo protected-graphs)]
+        (doseq [protected-graph protected-graphs]
+          (t/is (protected-graph? manager protected-graph) "Expected graph to be protected"))))))
+
+(t/deftest ensure-managed-user-graph-test
+  (tc/with-system
+    [system "repo.edn"]
+    (let [repo (:drafter/backend system)]
+      (t/testing "Valid user graph"
+        (fd/drop-all! repo)
+        (let [manager (create-manager repo)
+              graph-uri (URI. "http://example.com/graphs/test")]
+          (t/is (= false (mgmt/is-graph-managed? repo graph-uri)) "Graph exists before creation")
+          (ensure-managed-user-graph manager graph-uri)
+          (t/is (= true (mgmt/is-graph-managed? repo graph-uri)) "Expected managed graph to be created")))
+
+      (t/testing "Protected graph"
+        (fd/drop-all! repo)
+        (let [protected-graph-uri (URI. "http://cant-touch-this")
+              manager (create-manager repo #{protected-graph-uri})]
+          (t/is (thrown? Exception (ensure-managed-user-graph manager protected-graph-uri)) "Expected creation to fail")
+          (t/is (= false (mgmt/is-graph-managed? repo protected-graph-uri)) "Expected graph to not be created"))))))
+
+(defn is-draft-of? [repo draftset-ref live-graph-uri draft-graph-uri]
+  (let [draftset-uri (url/->java-uri draftset-ref)
+        bindings {:draft draft-graph-uri
+                  :live live-graph-uri
+                  :ds draftset-uri}]
+    (with-open [conn (repo/->connection repo)]
+      (sp/query "drafter/backend/draftset/graphs_test/ask-is-graph-draft-for.sparql" bindings conn))))
+
+(t/deftest create-user-graph-draft-test
+  (tc/with-system
+    [:drafter/backend]
+    [system "drafter/feature/empty-db-system.edn"]
+    (let [repo (:drafter/backend system)
+          protected-graph (URI. "http://cant-touch-this")
+          manager (create-manager repo #{protected-graph})
+          draftset-id (dsops/create-draftset! repo test-editor)]
+      (t/testing "When managed graph does not exist"
+        (let [live-graph-uri (URI. "http://test-graph-1")
+              draft-graph-uri (create-user-graph-draft manager draftset-id live-graph-uri)]
+          (t/is (mgmt/is-graph-managed? repo live-graph-uri) "Expected managed graph to be created")
+          (t/is (is-draft-of? repo draftset-id live-graph-uri draft-graph-uri) "Expected draft graph to be created")))
+
+      (t/testing "When managed graph exists"
+        (let [live-graph-uri (URI. "http://test-graph-2")]
+          (ensure-managed-user-graph manager live-graph-uri)
+          (let [draft-graph-uri (create-user-graph-draft manager draftset-id live-graph-uri)]
+            (t/is (is-draft-of? repo draftset-id live-graph-uri draft-graph-uri) "Expected draft graph to be created"))))
+
+      (t/testing "Protected graph"
+        (t/is (thrown? Exception (create-user-graph-draft manager draftset-id protected-graph)) "Should not create draft of protected graph")
+        (let [live->draft (dsops/get-draftset-graph-mapping repo draftset-id)]
+          (t/is (= false (contains? live->draft protected-graph)) "Draft graph should not be created"))))))
+
+(t/deftest delete-user-graph-not-in-live
+  (tc/with-system
+    [:drafter/backend]
+    [system "drafter/feature/empty-db-system.edn"]
+    (let [repo (:drafter/backend system)
+          manager (create-manager repo)
+          draftset-id (dsops/create-draftset! repo test-editor)
+          graph-to-delete (URI. "http://missing")]
+      (delete-user-graph manager draftset-id graph-to-delete)
+
+      (t/is (= false (mgmt/is-graph-managed? repo graph-to-delete)) "Non-existent graph should not be created")
+      (t/is (empty? (dsops/get-draftset-graph-mapping repo draftset-id)) "Draft graph should not be created"))))
+
+(t/deftest delete-user-graph-not-in-draftset
+  (tc/with-system
+    [:drafter/backend]
+    [system "drafter/feature/empty-db-system.edn"]
+    (let [initial-time-fn (fn [] #inst "2017")
+          repo (:drafter/backend system)
+          manager (create-manager repo)
+          draftset-id (dsops/create-draftset! repo test-editor)
+          live-graph (URI. "http://live")]
+      (tc/make-graph-live! repo live-graph initial-time-fn)
+      (delete-user-graph manager draftset-id live-graph)
+
+      (t/is (mgmt/is-graph-managed? repo live-graph) "Graph should still be managed")
+
+      (let [graph-mapping (dsops/get-draftset-graph-mapping repo draftset-id)]
+        (t/is (contains? graph-mapping live-graph) "Draft graph should exist for deleted graph")
+        (t/is (mgmth/draft-exists? repo (get graph-mapping live-graph)) "Draft graph should exist for deleted graph")))))
+
+(defn- get-modified-time [repo subject]
+  (with-open [conn (repo/->connection repo)]
+    (let [q (format "SELECT ?modified WHERE { <%s> <http://purl.org/dc/terms/modified> ?modified .}" subject)
+          results (vec (repo/query conn q))]
+      (-> results first :modified))))
+
+(t/deftest delete-user-graph-in-draftset
+  (tc/with-system
+    [:drafter/backend]
+    [system "drafter/feature/empty-db-system.edn"]
+    (let [initial-time-fn (fn [] #inst "2017")
+          repo (:drafter/backend system)
+          manager (create-manager repo)
+          draftset-id (dsops/create-draftset! repo test-editor)
+          live-graph (URI. "http://live")]
+
+      (tc/make-graph-live! repo live-graph initial-time-fn)
+
+      (let [draft-graph (tc/import-data-to-draft! repo live-graph (tc/test-triples (URI. "http://subject")) draftset-id)
+            initially-modified-at (get-modified-time repo live-graph)]
+
+        (t/is (mgmth/draft-exists? repo draft-graph) "Graph should still be managed")
+
+        (delete-user-graph manager draftset-id live-graph)
+
+        (let [subsequently-modified-at (get-modified-time repo draft-graph)]
+          (t/is (.isBefore initially-modified-at subsequently-modified-at) "Draft graph modified time should be updated"))
+
+        (t/is (mgmth/draft-exists? repo draft-graph) "Draft graph should still exist")
+        (t/is (= true (mgmt/graph-empty? repo draft-graph)) "Draft graph should be empty")))))
+
+(t/deftest delete-user-graph-protected
+  (tc/with-system
+    [:drafter/backend]
+    [system "drafter/feature/empty-db-system.edn"]
+    (let [repo (:drafter/backend system)
+          protected-graph (URI. "http://cant-touch-this")
+          manager (create-manager repo #{protected-graph})
+          draftset-id (dsops/create-draftset! repo test-editor)]
+      (tc/make-graph-live! repo protected-graph util/get-current-time)
+      (t/is (thrown? Exception (delete-user-graph manager draftset-id protected-graph)) "Should not delete protected graph")
+      (let [live->draft (dsops/get-draftset-graph-mapping repo draftset-id)]
+        (t/is (= false (contains? live->draft protected-graph)) "Should not create draft of protected graph")))))

--- a/drafter/test/drafter/feature/draftset/changes_test.clj
+++ b/drafter/test/drafter/feature/draftset/changes_test.clj
@@ -11,7 +11,8 @@
             [drafter.user-test :refer [test-editor test-manager test-publisher]]
             [drafter.util :as util]
             [grafter-2.rdf.protocols :refer [context]]
-            [grafter-2.rdf4j.io :refer [statements]])
+            [grafter-2.rdf4j.io :refer [statements]]
+            [drafter.backend.draftset.graphs :as graphs])
   (:import java.net.URI))
 
 (t/use-fixtures :each tc/with-spec-instrumentation)
@@ -27,51 +28,48 @@
     (tc/assert-spec ::ds/Draftset body)
     body))
 
-(tc/deftest-system-with-keys revert-changes-from-graph-only-in-draftset
-  [:drafter.stasher/repo :drafter/write-scheduler]
-  [{backend :drafter.stasher/repo} system]
-  (let [modified-time (constantly #inst "2017")
-        live-graph (URI. "http://live")
-        draftset-id (ops/create-draftset! backend test-editor)]
-    (mgmt/create-managed-graph! backend live-graph)
-    (let [draft-graph (mgmt/create-draft-graph! backend live-graph draftset-id modified-time)
-          result (sut/revert-graph-changes! backend draftset-id live-graph)]
-      (t/is (= :reverted result))
-      (t/is (= false (mgmth/draft-exists? backend draft-graph)))
-      (t/is (= false (mgmt/is-graph-managed? backend draft-graph))))))
-;; TODO: is this ^^ change right? The `live-graph` returns true, it does seem that
-;; it's managed.
+(t/deftest revert-changes-from-graph-only-in-draftset
+  (tc/with-system
+    [:drafter.stasher/repo ::graphs/manager :drafter/write-scheduler]
+    [{backend :drafter.stasher/repo graph-manager ::graphs/manager} system]
+    (let [live-graph (URI. "http://live")
+          draftset-id (ops/create-draftset! backend test-editor)]
+      (let [draft-graph (graphs/create-user-graph-draft graph-manager draftset-id live-graph)
+            result (sut/revert-graph-changes! backend draftset-id live-graph)]
+        (t/is (= :reverted result))
+        (t/is (= false (mgmth/draft-exists? backend draft-graph)))
+        (t/is (= false (mgmt/is-graph-managed? backend draft-graph)))))))
 
-(def keys-for-test [[:drafter/routes :draftset/api] :drafter.stasher/repo :drafter/write-scheduler])
+(def keys-for-test [[:drafter/routes :draftset/api] :drafter.stasher/repo :drafter/write-scheduler
+                    ::graphs/manager])
 
 (tc/deftest-system-with-keys revert-changes-from-graph-which-exists-in-live
   keys-for-test
-  [{handler [:drafter/routes :draftset/api] backend :drafter.stasher/repo} system]
+  [{handler [:drafter/routes :draftset/api] backend :drafter.stasher/repo graph-manager ::graphs/manager} system]
   (let [live-graph-uri (tc/make-graph-live! backend (URI. "http://live") (constantly #inst "2017"))
         draftset-id (ops/create-draftset! backend test-editor)
-        draft-graph-uri (ops/delete-draftset-graph! backend draftset-id live-graph-uri (constantly #inst "2018"))]
+        draft-graph-uri (graphs/delete-user-graph graph-manager draftset-id live-graph-uri)]
     (let [result (sut/revert-graph-changes! backend draftset-id live-graph-uri)]
       (t/is (= :reverted result))
       (t/is (mgmt/is-graph-managed? backend live-graph-uri))
       (t/is (= false (mgmth/draft-exists? backend draft-graph-uri))))))
 
-(tc/deftest-system-with-keys revert-change-from-graph-which-exists-independently-in-other-draftset
-  keys-for-test
-  [{handler [:drafter/routes :draftset/api] backend :drafter.stasher/repo} system]
-  (let [initial-time (constantly #inst "2017")
-        live-graph-uri (mgmt/create-managed-graph! backend (URI. "http://live"))
-        ds1-id (ops/create-draftset! backend test-editor "ds 1" "description 1" util/create-uuid initial-time)
-        ds2-id (ops/create-draftset! backend test-publisher "ds 2" "description 2" util/create-uuid initial-time)
+(t/deftest revert-change-from-graph-which-exists-independently-in-other-draftset
+  (tc/with-system
+    keys-for-test
+    [{handler [:drafter/routes :draftset/api] backend :drafter.stasher/repo graph-manager ::graphs/manager} system]
+    (let [initial-time (constantly #inst "2017")
+          live-graph-uri (graphs/ensure-managed-user-graph graph-manager (URI. "http://live"))
+          ds1-id (ops/create-draftset! backend test-editor "ds 1" "description 1" util/create-uuid initial-time)
+          ds2-id (ops/create-draftset! backend test-publisher "ds 2" "description 2" util/create-uuid initial-time)
+          draft-graph1-uri (graphs/create-user-graph-draft graph-manager ds1-id live-graph-uri)
+          draft-graph2-uri (graphs/create-user-graph-draft graph-manager ds2-id live-graph-uri)]
 
-        modified-time (constantly #inst "2018")
-        draft-graph1-uri (mgmt/create-draft-graph! backend live-graph-uri ds1-id modified-time)
-        draft-graph2-uri (mgmt/create-draft-graph! backend live-graph-uri ds2-id modified-time)]
-
-    (let [result (sut/revert-graph-changes! backend ds2-id live-graph-uri)]
-      (t/is (= :reverted result))
-      (t/is (mgmt/is-graph-managed? backend live-graph-uri))
-      (t/is (= false (mgmth/draft-exists? backend draft-graph2-uri)))
-      (t/is (mgmth/draft-exists? backend draft-graph1-uri)))))
+      (let [result (sut/revert-graph-changes! backend ds2-id live-graph-uri)]
+        (t/is (= :reverted result))
+        (t/is (mgmt/is-graph-managed? backend live-graph-uri))
+        (t/is (= false (mgmth/draft-exists? backend draft-graph2-uri)))
+        (t/is (mgmth/draft-exists? backend draft-graph1-uri))))))
 
 (tc/deftest-system-with-keys revert-non-existent-change-in-draftset
   keys-for-test

--- a/drafter/test/drafter/feature/draftset_data/common_test.clj
+++ b/drafter/test/drafter/feature/draftset_data/common_test.clj
@@ -29,9 +29,7 @@
 
 (tc/deftest-system-with-keys protected-graphs-test
   keys-for-test [system system-config]
-  (let [handler (get system [:drafter/routes :draftset/api])
-        backend (:drafter/backend system)]
-
+  (let [handler (get system [:drafter/routes :draftset/api])]
     (testing "Cannot operate on drafter's graphs"
       (let [g (URI. "http://publishmydata.com/graphs/drafter/drafts")
             draftset-location (help/create-draftset-through-api handler test-editor)

--- a/drafter/test/drafter/rdf/draftset_management/jobs_test.clj
+++ b/drafter/test/drafter/rdf/draftset_management/jobs_test.clj
@@ -5,8 +5,9 @@
             [drafter.rdf.sparql :as sparql]
             [drafter.test-common :as tc]
             [drafter.user-test :refer [test-editor]]
-            [drafter.write-scheduler :as scheduler]
-            [grafter-2.rdf.protocols :refer [->Triple]])
+            [grafter-2.rdf.protocols :refer [->Triple]]
+            [drafter.backend.draftset.operations :as ops]
+            [drafter.backend.draftset.draft-management :as mgmt])
   (:import java.net.URI))
 
 (t/use-fixtures :each tc/with-spec-instrumentation)
@@ -17,43 +18,55 @@
   (let [results (sparql/eager-query backend (tc/select-all-in-graph graph-uri))]
     (map (fn [{:keys [s p o]}] (->Triple s p o)) results)))
 
+(defn- job-resources [system]
+  {:backend (:drafter/backend system)
+   :global-writes-lock (:drafter/global-writes-lock system)
+   :graph-manager (:drafter.backend.draftset.graphs/manager system)})
 
-(tc/deftest-system copy-live-graph-into-draftset-test
-  ;; TODO port to use a test fixture
-  [{:keys [:drafter/backend :drafter/global-writes-lock]} "drafter/rdf/draftset-management/jobs.edn"]
-  (let [resources {:backend backend :global-writes-lock global-writes-lock}
-        draftset-id (dsops/create-draftset! backend test-editor)
-        live-triples (tc/test-triples (URI. "http://test-subject"))
-        live-graph-uri (tc/make-graph-live! backend (URI. "http://live") live-triples (constantly #inst "2015"))
-        {:keys [value-p] :as copy-job} (append-graph/copy-live-graph-into-draftset-job
-                                        resources
-                                        dummy
-                                        {:draftset-id draftset-id
-                                         :graph live-graph-uri})]
-    (scheduler/queue-job! copy-job)
+(t/deftest copy-live-graph-into-draftset-test
+  (tc/with-system
+    [{:keys [:drafter/backend :drafter/global-writes-lock] :as system} "drafter/rdf/draftset-management/jobs.edn"]
+    (let [resources (job-resources system)
+          draftset-id (dsops/create-draftset! backend test-editor)
+          live-triples (tc/test-triples (URI. "http://test-subject"))
+          live-graph-uri (tc/make-graph-live! backend (URI. "http://live") live-triples (constantly #inst "2015"))
+          copy-job (append-graph/copy-live-graph-into-draftset-job
+                     resources
+                     dummy
+                     {:draftset-id draftset-id
+                      :graph       live-graph-uri})]
+      (tc/exec-and-await-job-success copy-job)
+      (let [draft-graph (dsops/find-draftset-draft-graph backend draftset-id live-graph-uri)
+            draft-triples (get-graph-triples backend draft-graph)]
+        (t/is (= (set live-triples) (set draft-triples)))))))
 
-    @value-p
+(t/deftest copy-live-graph-into-existing-draft-graph-in-draftset-test
+  (tc/with-system
+    [{:keys [:drafter/backend] :as system} "drafter/rdf/draftset-management/jobs.edn"]
+    (let [resources (job-resources system)
+          draftset-id (dsops/create-draftset! backend test-editor)
+          live-triples (tc/test-triples (URI. "http://test-subject"))
+          live-graph-uri (tc/make-graph-live! backend (URI. "http://live") live-triples (constantly #inst "2015"))
+          initial-draft-triples (tc/test-triples (URI. "http://temp-subject"))
+          draft-graph-uri (tc/import-data-to-draft! backend live-graph-uri initial-draft-triples draftset-id)
+          copy-job (append-graph/copy-live-graph-into-draftset-job
+                     resources
+                     dummy
+                     {:draftset-id draftset-id
+                      :graph       live-graph-uri})]
+      (tc/exec-and-await-job-success copy-job)
+      (let [draft-triples (get-graph-triples backend draft-graph-uri)]
+        (t/is (= (set live-triples) (set draft-triples)))))))
 
-    (let [draft-graph (dsops/find-draftset-draft-graph backend draftset-id live-graph-uri)
-          draft-triples (get-graph-triples backend draft-graph)]
-      (t/is (= (set live-triples) (set draft-triples))))))
-
-(tc/deftest-system copy-live-graph-into-existing-draft-graph-in-draftset-test
-  [{:keys [:drafter/backend :drafter/global-writes-lock]} "drafter/rdf/draftset-management/jobs.edn"]
-  (let [resources {:backend backend :global-writes-lock global-writes-lock}
-        draftset-id (dsops/create-draftset! backend test-editor)
-        live-triples (tc/test-triples (URI. "http://test-subject"))
-        live-graph-uri (tc/make-graph-live! backend (URI. "http://live") live-triples (constantly #inst "2015"))
-        initial-draft-triples (tc/test-triples (URI. "http://temp-subject"))
-        draft-graph-uri (tc/import-data-to-draft! backend live-graph-uri initial-draft-triples draftset-id (constantly #inst "2016"))
-        {:keys [value-p] :as copy-job} (append-graph/copy-live-graph-into-draftset-job
-                                        resources
-                                        dummy
-                                        {:draftset-id draftset-id
-                                         :graph live-graph-uri})]
-
-    (scheduler/queue-job! copy-job)
-    @value-p
-
-    (let [draft-triples (get-graph-triples backend draft-graph-uri)]
-      (t/is (= (set live-triples) (set draft-triples))))))
+(t/deftest copy-live-graph-into-draftset-job-should-not-copy-protected-graphs
+  (tc/with-system
+    [{:keys [:drafter/backend :drafter/global-writes-lock] :as system} "drafter/rdf/draftset-management/jobs.edn"]
+    (let [{:keys [backend] :as resources} (job-resources system)
+          draftset-id (dsops/create-draftset! backend test-editor)
+          protected-graph mgmt/drafter-state-graph
+          params {:draftset-id draftset-id :graph protected-graph}
+          job (append-graph/copy-live-graph-into-draftset-job resources dummy params)
+          result (tc/exec-and-await-job job)
+          draft-graph (ops/find-draftset-draft-graph backend draftset-id protected-graph)]
+      (t/is (= :error (:type result)))
+      (t/is (nil? draft-graph)))))

--- a/drafter/test/drafter/rewrite_fixup_test.clj
+++ b/drafter/test/drafter/rewrite_fixup_test.clj
@@ -38,6 +38,7 @@
    :drafter/write-scheduler
    :drafter.routes.sparql/live-sparql-query-route
    :drafter.backend.live/endpoint
+   :drafter.backend.draftset.graphs/manager
    :drafter.common.config/sparql-query-endpoint])
 
 (def dg-q
@@ -353,30 +354,31 @@
      | 2 | delete!   | [q2]    | #{[s1 p1 o1 g1']              } |
      | 3 | publish!  | g1      | #{[s1 p1 o1 g1 ]              } |)))
 
-(tc/deftest-system-with-keys *_6_3_delete-variants
-  keys-for-test [system system-config]
-  ;; Delete variants
-  (let [{:keys [set-live! append! delete! delete-graph! publish! graph']}
-        (draftset-functions system)
-        g1 (random-uri 'g)
-        g2 (random-uri 'g)
-        g3 (random-uri 'g)
-        g4 (random-uri 'g)
-        q1 [s1 p1 o1 g1]
-        q2 [s2 p1 o1 g2]]
-    ;; T2 deleting a live graph by supplying all its triples
-    ;; T3 deleting a live graph through the delete graph op
-    ;; T5 deleting a graph (created in T4) that only existed in the draft by
-    ;; supplying triples
-    ;; T7 deleting a graph (created in T6) that only existed in the draft
-    ;; through the delete graph op
-    (test-table
-     |;T | Operation     | Args             | Expected State    |
-     | 1 | set-live!     | #{q1 q2}         | #{q1 q2}          |
-     | 2 | delete!       | #{q1}            | #{}               |
-     | 3 | delete-graph! | g2               | #{}               |
-     | 4 | append!       | #{[s3 p3 o3 g3]} | #{[s3 p3 o3 g3']} |
-     | 5 | delete!       | #{[s3 p3 o3 g3]} | #{}               |
-     | 6 | append!       | #{[s4 p4 o4 g4]} | #{[s4 p4 o4 g4']} |
-     | 7 | delete-graph! | g4               | #{}               |
-     | 8 | publish!      | g1 g2 g3 g4      | #{}               |)))
+(t/deftest *_6_3_delete-variants
+  (tc/with-system
+    keys-for-test [system system-config]
+    ;; Delete variants
+    (let [{:keys [set-live! append! delete! delete-graph! publish! graph']}
+          (draftset-functions system)
+          g1 (random-uri 'g)
+          g2 (random-uri 'g)
+          g3 (random-uri 'g)
+          g4 (random-uri 'g)
+          q1 [s1 p1 o1 g1]
+          q2 [s2 p1 o1 g2]]
+      ;; T2 deleting a live graph by supplying all its triples
+      ;; T3 deleting a live graph through the delete graph op
+      ;; T5 deleting a graph (created in T4) that only existed in the draft by
+      ;; supplying triples
+      ;; T7 deleting a graph (created in T6) that only existed in the draft
+      ;; through the delete graph op
+      (test-table
+        |                                                   ;T | Operation     | Args             | Expected State    |
+        | 1 | set-live! | #{q1 q2} | #{q1 q2} |
+        | 2 | delete! | #{q1} | #{} |
+        | 3 | delete-graph! | g2 | #{} |
+        | 4 | append! | #{[s3 p3 o3 g3]} | #{[s3 p3 o3 g3']} |
+        | 5 | delete! | #{[s3 p3 o3 g3]} | #{} |
+        | 6 | append! | #{[s4 p4 o4 g4]} | #{[s4 p4 o4 g4']} |
+        | 7 | delete-graph! | g4 | #{} |
+        | 8 | publish! | g1 g2 g3 g4 | #{} |))))

--- a/drafter/test/drafter/util_test.clj
+++ b/drafter/test/drafter/util_test.clj
@@ -23,11 +23,6 @@
           outer (Exception. "noooooo" middle)]
       (is (= [outer middle innermost] (get-causes outer))))))
 
-(deftest conf-if-test
-  (are [test col item expected] (= expected (conj-if test col item))
-       true [] 1 [1]
-       false [] 1 []))
-
 (deftest batch-partition-by-test
   (are [seq partition-fn output-batch-size take-batch-size expected]
     (contains? (set (permutations expected)) (batch-partition-by seq partition-fn output-batch-size take-batch-size))

--- a/drafter/test/resources/backend.edn
+++ b/drafter/test/resources/backend.edn
@@ -1,4 +1,3 @@
 {
  :drafter/backend {:repo #ig/ref :drafter.stasher/repo }
- :drafter/protected-graphs {:graphset #{#regex "http://publishmydata.com/graphs/drafter/.*"}}
  }

--- a/drafter/test/resources/drafter/backend/draftset/graphs_test/ask-is-graph-draft-for.sparql
+++ b/drafter/test/resources/drafter/backend/draftset/graphs_test/ask-is-graph-draft-for.sparql
@@ -1,0 +1,9 @@
+PREFIX drafter: <http://publishmydata.com/def/drafter/>
+
+ASK WHERE {
+  GRAPH <http://publishmydata.com/graphs/drafter/drafts> {
+    ?live a drafter:ManagedGraph .
+    ?live drafter:hasDraft ?draft .
+    ?draft drafter:inDraftSet ?ds .
+  }
+}

--- a/drafter/test/resources/drafter/routes/sparql-test/repo.edn
+++ b/drafter/test/resources/drafter/routes/sparql-test/repo.edn
@@ -25,10 +25,9 @@
 
  :drafter/backend {:repo #ig/ref :drafter.stasher/repo}
  :drafter/global-writes-lock {:fairness true :time 10 :unit :seconds}
- :drafter/protected-graphs {:graphset #{#regex "http://publishmydata.com/graphs/drafter/.*"}}
+ :drafter.backend.draftset.graphs/manager {:repo #ig/ref :drafter.stasher/repo}
 
  :drafter.backend.draftset/endpoint {:repo #ig/ref :drafter.stasher/repo}
-
 
  :drafter/write-scheduler {:port #long #or [#port #env DRAFTER_HTTP_PORT 3003]
                            :drafter/global-writes-lock #ig/ref :drafter/global-writes-lock}

--- a/drafter/test/resources/repo.edn
+++ b/drafter/test/resources/repo.edn
@@ -24,7 +24,7 @@
 
  :drafter/backend {:repo #ig/ref :drafter.stasher/repo}
  :drafter/global-writes-lock {:fairness true :time 10 :unit :seconds}
- :drafter/protected-graphs {:graphset #{#regex "http://publishmydata.com/graphs/drafter/.*"}}
+ :drafter.backend.draftset.graphs/manager {:repo #ig/ref :drafter.stasher/repo}
 
  :drafter.backend.draftset/endpoint {:repo #ig/ref :drafter.stasher/repo}
 

--- a/drafter/test/resources/web.edn
+++ b/drafter/test/resources/web.edn
@@ -63,7 +63,6 @@
 
  :drafter.feature.draftset.delete/handler {:drafter/backend #ig/ref :drafter/backend
                                            :drafter/global-writes-lock #ig/ref :drafter/global-writes-lock
-                                           :drafter/protected-graphs #ig/ref :drafter/protected-graphs
                                            :wrap-as-draftset-owner #ig/ref :drafter.feature.middleware/wrap-as-draftset-owner}
 
  :drafter.feature.draftset.options/handler {:drafter/backend #ig/ref :drafter/backend
@@ -75,11 +74,12 @@
 
  :drafter.feature.draftset-data.delete/delete-data-handler {:drafter/backend #ig/ref :drafter/backend
                                                             :drafter/global-writes-lock #ig/ref :drafter/global-writes-lock
-                                                            :drafter/protected-graphs #ig/ref :drafter/protected-graphs
+                                                            :drafter.backend.draftset.graphs/manager #ig/ref :drafter.backend.draftset.graphs/manager
                                                             :wrap-as-draftset-owner #ig/ref :drafter.feature.middleware/wrap-as-draftset-owner}
 
  :drafter.feature.draftset-data.delete-by-graph/remove-graph-handler {:drafter/backend #ig/ref :drafter/backend
                                                                       :drafter/global-writes-lock #ig/ref :drafter/global-writes-lock
+                                                                      :drafter.backend.draftset.graphs/manager #ig/ref :drafter.backend.draftset.graphs/manager
                                                                       :wrap-as-draftset-owner #ig/ref :drafter.feature.middleware/wrap-as-draftset-owner}
 
  :drafter.feature.draftset.changes/delete-changes-handler {:drafter/backend #ig/ref :drafter/backend
@@ -88,11 +88,12 @@
 
  :drafter.feature.draftset-data.append/data-handler {:drafter/backend #ig/ref :drafter/backend
                                                      :drafter/global-writes-lock #ig/ref :drafter/global-writes-lock
-                                                     :drafter/protected-graphs #ig/ref :drafter/protected-graphs
+                                                     :drafter.backend.draftset.graphs/manager #ig/ref :drafter.backend.draftset.graphs/manager
                                                      :wrap-as-draftset-owner #ig/ref :drafter.feature.middleware/wrap-as-draftset-owner}
 
  :drafter.feature.draftset-data.append-by-graph/handler {:drafter/backend #ig/ref :drafter/backend
                                                          :drafter/global-writes-lock #ig/ref :drafter/global-writes-lock
+                                                         :drafter.backend.draftset.graphs/manager #ig/ref :drafter.backend.draftset.graphs/manager
                                                          :wrap-as-draftset-owner #ig/ref :drafter.feature.middleware/wrap-as-draftset-owner}
 
  :drafter.feature.draftset.query/handler {:drafter/backend #ig/ref :drafter/backend
@@ -100,7 +101,7 @@
                                           :timeout-fn #ig/ref [:drafter.timeouts/timeout-query :drafter/draftset-timeout]}
 
  :drafter.feature.draftset.update/handler {:drafter/backend #ig/ref :drafter/backend
-                                           :drafter/protected-graphs #ig/ref :drafter/protected-graphs
+                                           :drafter.backend.draftset.graphs/manager #ig/ref :drafter.backend.draftset.graphs/manager
                                            :wrap-as-draftset-owner #ig/ref :drafter.feature.middleware/wrap-as-draftset-owner
                                            :max-update-size 50}
 


### PR DESCRIPTION
Issue #470 - Add drafter.backend.draftset.graphs namespace defining
a manager for the creation of managed and draft graphs. This is
configured with the set of protected graph specifications along
with the default http://publishmydata.com/graphs/drafter/.* graphs
which are always protected.

Remove the create-managed-graph!, delete-draftset-graph! and
create-draft-graph! functions from the draft-management namespace
and add corresponding function to the graph manager. The new
functions require the caller to specify whether the graph is
for protected or 'user' (i.e. non-protected) graphs. These check
that the graph is either protected or non-protected as required.

Update the append, delete, delete and copy graph jobs to use the
graph manager to create draft graphs. The set of protected graphs
is now only used by the graph manager so remove the
drafter/protected-graphs component from the integrant configuration.

Use the graph manager to check for protected graphs within the
draftset update query handler.

Remove conj-if macro and replace usages with cond-> macro and conj.