### PR TITLE
Remove the unused SparqlExecutor and ToRepository protocols

### DIFF
--- a/drafter/src/drafter/backend/draftset.clj
+++ b/drafter/src/drafter/backend/draftset.clj
@@ -1,5 +1,5 @@
 (ns drafter.backend.draftset
-  (:require [drafter.backend.common :as bprot :refer [->sesame-repo]]
+  (:require [drafter.backend.common :as bprot]
             [drafter.backend.draftset.draft-management :as mgmt]
             [drafter.backend.draftset.operations :as dsmgmt]
             [drafter.backend.draftset.rewrite-query :refer [rewrite-sparql-string]]
@@ -8,8 +8,7 @@
             [grafter-2.rdf4j.io :as rio]
             [grafter-2.rdf4j.repository :as repo]
             [integrant.core :as ig]
-            [clojure.spec.alpha :as s]
-            [clojure.tools.logging :as log])
+            [clojure.spec.alpha :as s])
   (:import java.io.Closeable
            [org.apache.jena.query QueryFactory Syntax]
            [org.eclipse.rdf4j.model Resource URI]
@@ -45,7 +44,7 @@
   (let [conn (repo/->connection repo)]
     (reify
       repo/IPrepareQuery
-      (repo/prepare-query* [this sparql-string dataset]
+      (prepare-query* [this sparql-string dataset]
         (prepare-rewrite-query conn
                                live->draft
                                sparql-string
@@ -54,7 +53,7 @@
 
       ;; TODO fix this interface to work with pull queries.
       proto/ISPARQLable
-      (proto/query-dataset [this sparql-string _model]
+      (query-dataset [this sparql-string _model]
         (let [pquery (repo/prepare-query* this sparql-string _model)]
           (repo/evaluate pquery)))
 
@@ -74,13 +73,8 @@
             (f iter)))))))
 
 (defrecord RewritingSesameSparqlExecutor [repo live->draft union-with-live?]
-  bprot/ToRepository
-  (->sesame-repo [_]
-    (log/warn "DEPRECATED CALL TO ->sesame-repo.  TODO: remove call")
-    (->sesame-repo repo))
-
   repo/ToConnection
-  (repo/->connection [this]
+  (->connection [this]
     (build-draftset-connection this)))
 
 (defn build-draftset-endpoint

--- a/drafter/src/drafter/backend/draftset/draft_management.clj
+++ b/drafter/src/drafter/backend/draftset/draft_management.clj
@@ -2,7 +2,6 @@
   (:require [clojure.set :as set]
             [clojure.string :as str]
             [clojure.tools.logging :as log]
-            [drafter.backend.common :refer [->repo-connection ->sesame-repo]]
             [drafter.rdf.drafter-ontology :refer :all]
             [drafter.rdf.sparql :as sparql :refer [update!]]
             [drafter.util :as util]
@@ -524,12 +523,12 @@ WHERE {
 
 (defn append-data-batch!
   "Appends a sequence of triples to the given draft graph."
-  [backend graph-uri triple-batch]
+  [repo graph-uri triple-batch]
   ;;NOTE: The remote sesame client throws an exception if an empty transaction is committed
   ;;so only create one if there is data in the batch
   (if-not (empty? triple-batch)
     ;;WARNING: This assumes the backend is a sesame backend which is
     ;;true for all current backends.
-    (with-open [conn (->repo-connection backend)]
+    (with-open [conn (repo/->connection repo)]
       (repo/with-transaction conn
         (sparql/add conn graph-uri triple-batch)))))

--- a/drafter/src/drafter/backend/rdf4j_repo.clj
+++ b/drafter/src/drafter/backend/rdf4j_repo.clj
@@ -2,31 +2,20 @@
   "Thin wrapper over a SparqlRepository as a configurable integrant component."
   (:require [clojure.spec.alpha :as s]
             [drafter.backend :as backend]
-            [clojure.string :as str]
             [clojure.tools.logging :as log]
-            [drafter.backend.common :as drpr]
-            [drafter.backend.draftset :as ds]
             [grafter-2.rdf4j.repository.registry :as reg]
-            [integrant.core :as ig])
+            [integrant.core :as ig]
+            [grafter-2.rdf4j.repository :as repo])
   (:import grafter_2.rdf.SPARQLRepository
            [org.eclipse.rdf4j.query.resultio.sparqljson SPARQLBooleanJSONParserFactory SPARQLResultsJSONParserFactory]
            [org.eclipse.rdf4j.query.resultio.sparqlxml SPARQLBooleanXMLParserFactory SPARQLResultsXMLParserFactory]
            [org.eclipse.rdf4j.query.resultio.binary BinaryQueryResultParserFactory]
            org.eclipse.rdf4j.query.resultio.text.BooleanTextParserFactory
-           org.eclipse.rdf4j.repository.Repository
            org.eclipse.rdf4j.rio.nquads.NQuadsParserFactory
            org.eclipse.rdf4j.rio.ntriples.NTriplesParserFactory
            org.eclipse.rdf4j.rio.turtle.TurtleParserFactory
            org.eclipse.rdf4j.rio.trig.TriGParserFactory
            org.eclipse.rdf4j.rio.binary.BinaryRDFParserFactory))
-
-(extend-type Repository
-  drpr/SparqlExecutor
-  (drpr/prepare-query [this sparql-string]
-    (drpr/prep-and-validate-query this sparql-string))
-
-  drpr/ToRepository
-  (drpr/->sesame-repo [r] r))
 
 (defn create-sparql-repository
   "Creates a new SPARQL repository with the given query and update
@@ -37,7 +26,6 @@
     (.enableQuadMode repo true)
     (log/info "Initialised repo at QUERY=" query-endpoint ", UPDATE=" update-endpoint)
     repo))
-
 
 ;; TODO:
 ;;
@@ -85,7 +73,6 @@
   (log/info "Initialising Backend")
   (get-backend opts))
 
-
-(defmethod ig/halt-key! :drafter.backend/rdf4j-repo [k backend]
+(defmethod ig/halt-key! :drafter.backend/rdf4j-repo [_k repo]
   (log/info "Halting Backend")
-  (drpr/stop-backend backend))
+  (repo/shutdown repo))

--- a/drafter/src/drafter/feature/draftset_data/delete.clj
+++ b/drafter/src/drafter/feature/draftset_data/delete.clj
@@ -1,6 +1,5 @@
 (ns drafter.feature.draftset-data.delete
   (:require [clojure.spec.alpha :as s]
-            [drafter.backend.common :refer [->sesame-repo]]
             [drafter.backend.draftset.draft-management :as mgmt]
             [drafter.backend.draftset.operations :as ops]
             [drafter.backend.draftset.rewrite-result :refer [rewrite-statement]]
@@ -35,7 +34,7 @@
           (if (mgmt/is-graph-managed? repo live-graph)
             (if-let [draft-graph-uri (get live->draft live-graph)]
               (do
-                (with-open [conn (repo/->connection (->sesame-repo repo))]
+                (with-open [conn (repo/->connection repo)]
                   (touch-graph-in-draftset! conn draftset-ref draft-graph-uri job-started-at)
                   (let [rewritten-statements (map #(rewrite-statement live->draft %) batch)
                         sesame-statements (map quad->backend-quad rewritten-statements)

--- a/drafter/src/drafter/handler.clj
+++ b/drafter/src/drafter/handler.clj
@@ -1,7 +1,6 @@
 (ns drafter.handler
   (:require [compojure.core :refer [context defroutes GET]]
             [compojure.route :as route]
-            [drafter.backend.common :refer [stop-backend]]
             [drafter.env :as denv]
             [drafter.middleware :as middleware]
             [drafter.routes.pages :refer [pages-routes]]
@@ -75,12 +74,3 @@
 
 (defmethod ig/init-key :drafter.handler/app [k opts]
   (build-handler opts))
-
-;; TODO remove/replace
-#_(defn destroy
-  "destroy will be called when your application
-   shuts down, put any clean up code here"
-  []
-  (log/info "drafter is shutting down.  Please wait (this can take a minute)...")
-  (stop-backend backend)
-  (log/info "drafter has shut down."))

--- a/drafter/src/drafter/rdf/sesame.clj
+++ b/drafter/src/drafter/rdf/sesame.clj
@@ -1,6 +1,5 @@
 (ns drafter.rdf.sesame
   (:require [clojure.tools.logging :as log]
-            [drafter.backend.common :refer [->sesame-repo]]
             [drafter.backend.draftset.arq :refer [sparql-string->arq-query]]
             [drafter.rdf.draftset-management.job-util :as jobs]
             [grafter-2.rdf4j.io :refer [statements]]

--- a/drafter/src/drafter/stasher.clj
+++ b/drafter/src/drafter/stasher.clj
@@ -11,7 +11,6 @@
             [clojure.tools.logging :as log]
             [cognician.dogstatsd :as dd]
             [me.raynes.fs :as fs]
-            [drafter.backend.common :as drpr]
             [grafter-2.rdf4j.repository.registry :as reg]
             [grafter-2.rdf4j.io :as rio]
             [drafter.stasher.formats :as formats]
@@ -26,23 +25,12 @@
            (org.eclipse.rdf4j.query.resultio TupleQueryResultFormat BooleanQueryResultFormat QueryResultIO
                                              TupleQueryResultWriter BooleanQueryResultParserRegistry
                                              TupleQueryResultParserRegistry)
-           org.eclipse.rdf4j.repository.Repository
            org.eclipse.rdf4j.repository.RepositoryConnection
            (org.eclipse.rdf4j.repository.sparql.query SPARQLBooleanQuery SPARQLGraphQuery SPARQLTupleQuery SPARQLUpdate)
            (org.eclipse.rdf4j.rio RDFParser RDFFormat RDFHandler RDFWriter RDFParserRegistry)
            (org.eclipse.rdf4j.query.resultio TupleQueryResultParser BooleanQueryResultParser)
            (java.util.concurrent ThreadPoolExecutor TimeUnit ArrayBlockingQueue)
            java.time.OffsetDateTime))
-
-(extend-type Repository
-  ;; TODO can probably remove this...
-  drpr/ToRepository
-  (drpr/->sesame-repo [r] r))
-
-(extend-type RepositoryConnection
-  drpr/SparqlExecutor
-  (drpr/prepare-query [this sparql-string]
-    (drpr/prep-and-validate-query this sparql-string)))
 
 (s/def ::core-pool-size pos-int?)
 (s/def ::max-pool-size pos-int?)
@@ -652,7 +640,7 @@
 
 (defmethod ig/halt-key! :drafter.stasher/repo [_ repo]
   (log/info "Shutting down stasher repo")
-  (drpr/stop-backend repo))
+  (repo/shutdown repo))
 
 
 (defmethod ig/init-key :drafter.stasher/cache [_ opts]

--- a/drafter/test/drafter/backend/draftset/rewrite_result_test.clj
+++ b/drafter/test/drafter/backend/draftset/rewrite_result_test.clj
@@ -2,7 +2,6 @@
   (:require [clojure.java.io :as io]
             [clojure.set :as set]
             [clojure.test :refer :all]
-            [drafter.backend.common :refer [prepare-query]]
             [drafter.backend.draftset.draft-management
              :refer
              [append-data-batch! create-draft-graph!]]
@@ -15,8 +14,7 @@
             [grafter-2.rdf4j.repository :as repo]
             [schema.test :refer [validate-schemas]]
             [drafter.test-common :as tc])
-  (:import java.net.URI
-           org.eclipse.rdf4j.model.impl.URIImpl))
+  (:import [java.net URI]))
 
 (use-fixtures :each
   validate-schemas
@@ -84,7 +82,7 @@
   [db query-str query-substitutions]
   (with-open [conn (repo/->connection db)]
     (let [rewritten-query (rewrite-sparql-string query-substitutions query-str)
-          prepared-query (prepare-query conn rewritten-query)]
+          prepared-query (repo/prepare-query conn rewritten-query)]
       (rewrite-graph-results query-substitutions prepared-query))))
 
 (defn first-result [results key]

--- a/drafter/test/drafter/backend/draftset_test.clj
+++ b/drafter/test/drafter/backend/draftset_test.clj
@@ -4,8 +4,7 @@
             [drafter.fixtures.state-1 :as state]
             [drafter.test-common :as tc :refer [deftest-system-with-keys]]
             [grafter-2.rdf4j.io :as rio]
-            [grafter-2.rdf4j.repository :as repo])
-  (:import java.net.URI))
+            [grafter-2.rdf4j.repository :as repo]))
 
 (t/use-fixtures :each tc/with-spec-instrumentation)
 


### PR DESCRIPTION
Issue #474 - The SparqlExecutor was previously implemented by each
Drafter 'backend' (sesame native, stardog and remote SPARQL
repository) implementation for submitting SPARQL queries. Querying
code now uses the grafter ToConnection and PrepareQuery protocol
for submitting queries so the implementations are no longer needed.
Remove the protocol and the implementations.

Since queryable data sources can be queried directly access to the
underlying sesame repository via the ToRepository protocol is also
no longer required.

Remove the stop-backend function and call shutdown on repositories
directly.