### PR TITLE
catch SocketTimeoutException thrown on read timeout when executing slow queries

### DIFF
--- a/drafter/test/resources/drafter/feature/empty-db-system-short-timeout.edn
+++ b/drafter/test/resources/drafter/feature/empty-db-system-short-timeout.edn
@@ -1,0 +1,9 @@
+#merge
+[#include "empty-db-system.edn"
+ {[:drafter.timeouts/timeout-query :drafter/live-timeout]
+  {:endpoint-timeout 1
+   :jws-signing-key #env DRAFTER_JWS_SIGNING_KEY}
+
+  [:drafter.timeouts/timeout-query :drafter/draftset-timeout]
+  {:endpoint-timeout 1
+   :jws-signing-key #env DRAFTER_JWS_SIGNING_KEY }}]


### PR DESCRIPTION
I haven't entirely figured out when a `org.eclipse.rdf4j.query.QueryInterruptedException` is thrown instead of a `java.net.SocketTimeoutException`, but a long running query will result in the latter being thrown, which isn't currently handled. Catch it and return a 503.

closes #482 