### PR TITLE
Remove the dev ring-spec dependency

### DIFF
--- a/drafter/deps.edn
+++ b/drafter/deps.edn
@@ -107,8 +107,7 @@
                               org.clojure/data.json {:mvn/version "0.2.6"}
                               org.clojure/test.check {:mvn/version "0.9.0"}
                               ring-mock/ring-mock {:mvn/version "0.1.5"}
-                              ring/ring-devel {:mvn/version "1.7.1" :exclusions [org.clojure/java.classpath org.clojure/tools.reader]}
-                              ring/ring-spec {:mvn/version "0.0.4"}}}
+                              ring/ring-devel {:mvn/version "1.7.1" :exclusions [org.clojure/java.classpath org.clojure/tools.reader]}}}
 
            :test {:extra-paths ["env/dev/clj" "test" "test/resources"]}
 

--- a/drafter/test/drafter/test_common.clj
+++ b/drafter/test/drafter/test_common.clj
@@ -5,7 +5,6 @@
             [clojure.pprint :as pp]
             [clojure.spec.test.alpha :as st]
             [clojure.spec.alpha :as s]
-            [ring.core.spec]
             [clojure.test :refer :all]
             [drafter.backend.draftset.draft-management :refer [migrate-graphs-to-live!]]
             [drafter.main :as main]


### PR DESCRIPTION
Issue #483 - Remove the ring-spec dependency and remove the import
from test-common to prevent the conflicting definition of
:ring/reponse being loaded.