### PR TITLE
Rewrite append job to use explicit state transitions

### DIFF
--- a/drafter/src/drafter/feature/draftset_data/append.clj
+++ b/drafter/src/drafter/feature/draftset_data/append.clj
@@ -2,23 +2,17 @@
   "Appending quads & triples into a draftset."
   (:require [clojure.spec.alpha :as s]
             [drafter.backend.draftset.draft-management :as mgmt]
-            [drafter.backend.draftset.operations :as ops]
             [drafter.draftset :as ds]
             [drafter.feature.draftset-data.common :as ds-data-common]
             [drafter.feature.draftset-data.middleware :as dset-middleware]
             [drafter.middleware :refer [require-rdf-content-type temp-file-body inflate-gzipped]]
             [drafter.rdf.draftset-management.job-util :as jobs]
-            [drafter.rdf.sesame :as dses :refer [is-quads-format?]]
-            [drafter.rdf.sparql :as sparql]
             [drafter.responses :as response]
-            [drafter.util :as util]
-            [drafter.write-scheduler :as writes]
             [grafter-2.rdf.protocols :as pr]
+            [grafter-2.rdf4j.io :as gio]
             [integrant.core :as ig]
-            [drafter.async.jobs :as ajobs]
             [drafter.requests :as req]
             [grafter-2.rdf4j.repository :as repo]
-            [drafter.backend.draftset.graphs :as graphs]
             [drafter.time :as time]))
 
 (defn append-data-batch!
@@ -34,81 +28,90 @@
       (mgmt/rewrite-draftset! conn {:draftset-uri (ds/->draftset-uri draftset-ref)
                                     :deleted :ignore}))))
 
-(declare append-draftset-quads)
+(defn- append-to-draft-graph [{:keys [draftset-ref job-started-at] :as context} draft-graph-uri triples]
+  (let [repo (ds-data-common/get-repo context)]
+    (append-data-batch! repo draft-graph-uri triples draftset-ref)
+    (ds-data-common/touch-graph-in-draftset! repo draftset-ref draft-graph-uri job-started-at)))
 
-(defn- append-draftset-quads*
-  [quad-batches live->draft resources job-started-at job draftset-ref state]
-  (let [repo (-> resources :backend :repo)]
-    (if-let [batch (first quad-batches)]
-      (let [{:keys [graph-uri triples]} (ds-data-common/quad-batch->graph-triples batch)]
-        (if-let [draft-graph-uri (get live->draft graph-uri)]
-          (do
-            (append-data-batch! repo draft-graph-uri triples draftset-ref)
-            (ds-data-common/touch-graph-in-draftset! repo draftset-ref draft-graph-uri job-started-at)
+(defn- consume-batch
+  "Consumes the current quad batch and returns the new state"
+  [state quad-batches]
+  (if-let [remaining-batches (next quad-batches)]
+    (assoc state :quad-batches remaining-batches)
+    (ds-data-common/done-state)))
 
-            (let [next-job (ajobs/create-child-job
-                            job
-                            (partial append-draftset-quads resources draftset-ref live->draft (rest quad-batches) (merge state {:op :append})))]
-              (writes/queue-job! next-job)))
-          ;;NOTE: do this immediately instead of scheduling a
-          ;;continuation since we haven't done any real work yet
-          (append-draftset-quads resources draftset-ref live->draft quad-batches (merge state {:op :copy-graph :graph graph-uri}) job)))
-      (ajobs/job-succeeded! job))))
+(defn- append-state [{:keys [quad-batches live->draft] :as state} context]
+  (let [repo (ds-data-common/get-repo context)
+        batch (first quad-batches)]
+    (let [{:keys [graph-uri triples]} (ds-data-common/quad-batch->graph-triples batch)
+          draft-graph-uri (get live->draft graph-uri)]
+      (cond
+        ;;draft graph already exists so append current batch
+        (some? draft-graph-uri)
+        (do
+          (append-to-draft-graph context draft-graph-uri triples)
+          (consume-batch state quad-batches))
 
-(defn- copy-graph-for-append*
-  [state draftset-ref {:keys [graph-manager] :as resources} live->draft quad-batches job]
-  (let [live-graph-uri (:graph state)
-        draft-graph-uri (graphs/create-user-graph-draft graph-manager draftset-ref live-graph-uri)
-        live->draft (assoc live->draft live-graph-uri draft-graph-uri)]
-    (ds-data-common/lock-writes-and-copy-graph resources live-graph-uri draft-graph-uri {:silent true})
-    ;; Now resume appending the batch
-    (append-draftset-quads resources draftset-ref live->draft quad-batches (merge state {:op :append}) job)))
+        ;;live graph exists so clone it and update the draft graph mapping
+        (mgmt/is-graph-live? repo graph-uri)
+        (let [draft-graph-uri (ds-data-common/copy-user-graph context graph-uri)]
+          (ds-data-common/add-draft-graph state graph-uri draft-graph-uri))
 
-(defn- append-draftset-quads
-  [resources draftset-ref live->draft quad-batches state job]
-  (let [{:keys [op job-started-at]} state]
-    (case op
-      :append
-      (append-draftset-quads* quad-batches live->draft resources job-started-at job draftset-ref state)
+        ;;no draft exists or live graph exists so create the managed graph and draft graph in
+        ;;draftset before appending current batch
+        :else
+        (let [draft-graph-uri (ds-data-common/create-user-graph-draft context graph-uri)
+              state (ds-data-common/add-draft-graph state graph-uri draft-graph-uri)]
+          (append-to-draft-graph context draft-graph-uri triples)
+          (consume-batch state quad-batches))))))
 
-      :copy-graph
-      (copy-graph-for-append* state draftset-ref resources live->draft quad-batches job))))
+(defn- start-state [{:keys [quad-batches] :as state} context]
+  (if (seq quad-batches)
+    (append-state (ds-data-common/move-to state ::append) context)
+    (ds-data-common/done-state)))
 
-(defn- get-quads [tempfile {:keys [rdf-format graph]}]
-  (let [statements (dses/read-statements tempfile rdf-format)]
-    (if (is-quads-format? rdf-format)
-      statements
-      (map #(util/make-quad-statement % graph) statements))))
-
-(defn- validate-quad [quad]
+(defn- validate-non-blank-node
+  "Returns quad if its graph component is not a blank node otherwise raises
+   an exception"
+  [quad]
   (let [g (pr/context quad)]
     (if (pr/blank-node? g)
       (throw (ex-info "Blank node as graph ID" {:type :error}))
       quad)))
 
+(defn validate-graph-source
+  "Wraps an ITripleReadable source with one that validates each graph in the
+   returned sequence is not a blank node."
+  [inner]
+  (reify pr/ITripleReadable
+    (to-statements [_this _opts]
+      (map validate-non-blank-node (gio/statements inner)))))
+
+(defn append-state-machine
+  "Creates a state machine for append data jobs"
+  []
+  (reify ds-data-common/StateMachine
+    (create-initial-state [_this live->draft source]
+      (let [validating-source (validate-graph-source source)]
+        (ds-data-common/init-state ::start live->draft validating-source)))
+    (step [_this state context]
+      (case (ds-data-common/state-label state)
+        ::start (start-state state context)
+        ::append (append-state state context)
+        (ds-data-common/unknown-label state)))))
+
 (defn append-data-to-draftset-job
-  [tempfile {:keys [backend] :as resources} user-id {:keys [draftset-id metadata] :as params} clock]
-  (let [quads (map validate-quad (get-quads tempfile params))]
-    (jobs/make-job user-id
-                   :background-write
-                   (jobs/job-metadata backend draftset-id 'append-data-to-draftset metadata)
-                   (fn [job]
-                     (let [graph-map (ops/get-draftset-graph-mapping backend draftset-id)
-                           quad-batches (util/batch-partition-by quads pr/context jobs/batched-write-size)
-                           now (time/now clock)]
-                       (append-draftset-quads resources
-                                              draftset-id
-                                              graph-map
-                                              quad-batches
-                                              {:op :append :job-started-at now}
-                                              job))))))
+  "Creates a job to append quads from a source into a draft on behalf of the given user"
+  [source {:keys [backend] :as resources} user-id draftset-id clock metadata]
+  (let [job-meta (jobs/job-metadata backend draftset-id 'append-data-to-draftset metadata)
+        sm (append-state-machine)]
+    (ds-data-common/create-state-machine-job resources user-id draftset-id source clock job-meta sm)))
 
 (defn data-handler
   "Ring handler to append data into a draftset."
   [{:keys [:drafter/backend :drafter/global-writes-lock
            :drafter.backend.draftset.graphs/manager
-           ::time/clock
-           wrap-as-draftset-owner]}]
+           ::time/clock wrap-as-draftset-owner]}]
   (let [resources {:backend backend
                    :global-writes-lock global-writes-lock
                    :graph-manager manager}]
@@ -117,10 +120,12 @@
       (dset-middleware/require-graph-for-triples-rdf-format
        (temp-file-body
          (inflate-gzipped
-           (fn [{:keys [params body] :as request}]
-             (let [user-id (req/user-id request)]
-               (let [append-job (append-data-to-draftset-job body resources user-id params clock)]
-                 (response/submit-async-job! append-job)))))))))))
+           (fn [{:keys [params] :as request}]
+             (let [{:keys [draftset-id metadata]} params
+                   user-id (req/user-id request)
+                   source (ds-data-common/get-request-statement-source request)
+                   append-job (append-data-to-draftset-job source resources user-id draftset-id clock metadata)]
+               (response/submit-async-job! append-job))))))))))
 
 (defmethod ig/pre-init-spec ::data-handler [_]
   (s/keys :req [:drafter/backend

--- a/drafter/src/drafter/feature/draftset_data/common.clj
+++ b/drafter/src/drafter/feature/draftset_data/common.clj
@@ -1,18 +1,23 @@
 (ns drafter.feature.draftset-data.common
   (:require
    [clojure.string :as str]
+   [drafter.async.jobs :as ajobs]
    [drafter.backend.draftset.draft-management :as mgmt]
+   [drafter.backend.draftset.graphs :as graphs]
+   [drafter.backend.draftset.operations :as ops]
    [drafter.draftset :as ds]
    [drafter.rdf.drafter-ontology :refer :all]
+   [drafter.rdf.draftset-management.job-util :as jobs]
+   [drafter.rdf.sesame :as ses]
    [drafter.rdf.sparql :as sparql]
+   [drafter.time :as time]
    [drafter.util :as util]
    [drafter.write-scheduler :as writes]
-   [grafter-2.rdf.protocols :as rdf :refer [context map->Triple]]
-   [grafter-2.rdf4j.io :refer [rdf-writer]]
+   [grafter-2.rdf.protocols :as pr :refer [context]]
+   [grafter-2.rdf4j.io :as gio :refer [rdf-writer]]
    [grafter.vocabularies.dcterms :refer [dcterms:modified]])
   (:import
-   java.io.StringWriter
-   java.net.URI))
+   java.io.StringWriter))
 
 (defn touch-graph-in-draftset
   "Builds and returns an update string to update the dcterms:modified and
@@ -40,14 +45,28 @@
   currently supported."
   [quads]
   {:pre [(not (empty? quads))]}
-  (let [graph-uri (context (first quads))]
+  (let [graph-uri (pr/context (first quads))]
     (if (some? graph-uri)
-      {:graph-uri graph-uri :triples (map map->Triple quads)}
-      (let [sw (StringWriter.)
-            msg (format "All statements must have an explicit target graph")]
-        (rdf/add (rdf-writer sw :format :nq) (take 5 quads))
+      {:graph-uri graph-uri :triples (map pr/map->Triple quads)}
+      (let [sw (StringWriter.)]
+        (pr/add (rdf-writer sw :format :nq) (take 5 quads))
         (throw (IllegalArgumentException.
                 (str "All statements must have an explicit target graph. The following statements have no graph:\n" sw)))))))
+
+(defn- source->quad-batches
+  "Reads a statement source into a sequence of quad batches"
+  [source]
+  (let [quads (gio/statements source)]
+    (util/batch-partition-by quads pr/context jobs/batched-write-size)))
+
+(defn get-request-statement-source
+  "Returns an ITripleReadable statement source from an incoming jobs request"
+  [{:keys [body params] :as request}]
+  (let [{:keys [rdf-format graph]} params
+        source (ses/->FormatStatementSource body rdf-format)]
+    (if (ses/is-quads-format? rdf-format)
+      source
+      (ses/->GraphTripleStatementSource source graph))))
 
 (defn lock-writes-and-copy-graph
   "Calls mgmt/copy-graph to copy a live graph into the draftset, but
@@ -61,3 +80,116 @@
     ;; likely be blocked inside the database anyway, so this way we
     ;; can fail them fast when they are run behind a long running op.
     (mgmt/copy-graph (:backend resources) live-graph-uri draft-graph-uri opts)))
+
+(defn job-context
+  "Creates a static 'context' for an update job. The context contains data that does not change
+   throughout the execution of the job (in contrast to the state)."
+  [resources draftset-ref clock]
+  {:resources resources
+   :draftset-ref draftset-ref
+   :job-started-at (time/now clock)})
+
+(defn get-repo
+  "Fetch the repository from the job context"
+  [context]
+  (get-in context [:resources :backend]))
+
+(defn- graph-manager [context]
+  (get-in context [:resources :graph-manager]))
+
+(defn create-user-graph-draft
+  "Creates a new draft for a live graph within the draft of the executing job"
+  [{:keys [draftset-ref] :as context} live-graph-uri]
+  (graphs/create-user-graph-draft (graph-manager context) draftset-ref live-graph-uri))
+
+(defn copy-user-graph
+  "Copies a live graph into a new draft graph within the draft of the executing job"
+  [{:keys [resources] :as context} live-graph-uri]
+  (let [draft-graph-uri (create-user-graph-draft context live-graph-uri)]
+    (lock-writes-and-copy-graph resources live-graph-uri draft-graph-uri {:silent true})
+    draft-graph-uri))
+
+(defn get-draft-graph
+  "Returns the draft graph URI for the specified live graph in the current state or
+   nil if no draft exists"
+  [{:keys [live->draft] :as state} live-graph-uri]
+  (get live->draft live-graph-uri))
+
+(defn add-draft-graph
+  "Adds a live->draft graph mapping to the current state and returns the new state"
+  [state live-graph-uri draft-graph-uri]
+  (update state :live->draft assoc live-graph-uri draft-graph-uri))
+
+(defn init-state
+  "Creates an initial state with the given label, live->draft graph mapping and
+   statement source"
+  [label live->draft source]
+  (let [quad-batches (source->quad-batches source)]
+    {:label label :live->draft live->draft :quad-batches quad-batches}))
+
+(defn done-state
+  "Returns a state indicating the job has completed"
+  ([] {:label ::done})
+  ([result] {:label ::done ::result result}))
+
+(defn- job-done? [{:keys [label]}]
+  (= ::done label))
+
+(defn move-to
+  "Updates the current state to the one with the given label"
+  [state label]
+  (assoc state :label label))
+
+(defn state-label
+  "Returns the label of the current job state"
+  [state]
+  (:label state))
+
+(defn unknown-label [{:keys [label] :as state}]
+  (throw (ex-info (str "Unknown label " label)
+                  {:state state})))
+
+(defprotocol StateMachine
+  "Represents a state machine for a draftset update job."
+  (create-initial-state [this live->draft source]
+    "Creates the initial state to execute given a statement source and the current
+     live->draft graph mapping for the current draftset")
+  (step [this state context]
+    "Execute a single transition of this machine from the given current state and
+     return the transitioned-to state."))
+
+(defn exec-state-machine-job
+  "Executes the given state machine asynchronously within a job. Each state transition
+   is queued as a continuation until the job is completed with the final result."
+  [sm live->draft source context job]
+  (letfn [(step-job [state job]
+            (let [next-state (step sm state context)]
+              (if (job-done? next-state)
+                (if-let [result (::result next-state)]
+                  (ajobs/job-succeeded! job result)
+                  (ajobs/job-succeeded! job))
+                (let [next-job (ajobs/create-child-job job (partial step-job next-state))]
+                  (writes/queue-job! next-job)))))]
+    (let [initial-state (create-initial-state sm live->draft source)]
+      (step-job initial-state job))))
+
+(defn exec-state-machine-sync
+  "Executes the given state machine synchronously and returns the result"
+  [sm live->draft source context]
+  (let [initial-state (create-initial-state sm live->draft source)]
+    (loop [next-state (step sm initial-state context)]
+      (if (job-done? next-state)
+        (::result next-state)
+        (recur (step sm next-state context))))))
+
+(defn create-state-machine-job
+  "Creates a draftset update job for a user within a draftset for a source of quads and an
+   update state machine."
+  [{:keys [backend] :as resources} user-id draftset-ref source clock job-metadata sm]
+  (jobs/make-job user-id
+                 :background-write
+                 job-metadata
+                 (fn [job]
+                   (let [live->draft (ops/get-draftset-graph-mapping backend draftset-ref)
+                         context (job-context resources draftset-ref clock)]
+                     (exec-state-machine-job sm live->draft source context job)))))

--- a/drafter/src/drafter/rdf/sesame.clj
+++ b/drafter/src/drafter/rdf/sesame.clj
@@ -2,7 +2,10 @@
   (:require [drafter.backend.draftset.arq :refer [sparql-string->arq-query]]
             [drafter.rdf.draftset-management.job-util :as jobs]
             [grafter-2.rdf4j.io :refer [statements] :as gio]
-            [grafter.url :as url])
+            [grafter.url :as url]
+            [grafter-2.rdf4j.io :refer [statements]]
+            [grafter-2.rdf.protocols :as pr]
+            [drafter.util :as util])
   (:import [org.eclipse.rdf4j.query BindingSet BooleanQuery GraphQuery TupleQuery TupleQueryResultHandler TupleQueryResult Update Binding]
            [org.eclipse.rdf4j.query.resultio QueryResultIO QueryResultWriter]
            [org.eclipse.rdf4j.rio RDFHandler Rio RDFFormat]
@@ -55,6 +58,21 @@
    (statements input
                :format rdf-format
                :buffer-size batch-size)))
+
+(defrecord FormatStatementSource [inner-source format]
+  pr/ITripleReadable
+  (to-statements [_this _options]
+    (read-statements inner-source format)))
+
+(defrecord GraphTripleStatementSource [triple-source graph]
+  pr/ITripleReadable
+  (to-statements [_this options]
+    (map #(util/make-quad-statement % graph) (pr/to-statements triple-source options))))
+
+(defrecord CollectionStatementSource [statements]
+  pr/ITripleReadable
+  (to-statements [_this _options]
+    statements))
 
 (defn get-query-type
   "Returns a keyword indicating the type query represented by the

--- a/drafter/test/drafter/feature/draftset/delete_test.clj
+++ b/drafter/test/drafter/feature/draftset/delete_test.clj
@@ -243,20 +243,21 @@
         job-result (tc/await-completion (get-in delete-response [:body :finished-job]))]
     (is (jobs/failed-job-result? job-result))))
 
-(tc/deftest-system-with-keys delete-triples-from-graph-in-live
-  keys-for-test
-  [{handler [:drafter/routes :draftset/api]} system]
-  (let [quads (statements "test/resources/test-draftset.trig")
-        grouped-quads (group-by context quads)
-        [live-graph graph-quads] (first grouped-quads)
-        draftset-location (help/create-draftset-through-api handler test-editor)]
+(t/deftest delete-triples-from-graph-in-live
+  (tc/with-system
+    keys-for-test
+    [{handler [:drafter/routes :draftset/api]} system]
+    (let [quads (statements "test/resources/test-draftset.trig")
+          grouped-quads (group-by context quads)
+          [live-graph graph-quads] (first grouped-quads)
+          draftset-location (help/create-draftset-through-api handler test-editor)]
 
-    (help/publish-quads-through-api handler quads)
-    (let [draftset-info (help/delete-quads-through-api handler test-editor draftset-location [(first graph-quads)])
-          draftset-quads (help/get-draftset-quads-through-api handler draftset-location test-editor "false")
-          expected-quads (help/eval-statements (rest graph-quads))]
-      (is (= #{live-graph} (tc/key-set (:changes draftset-info))))
-      (is (= (set expected-quads) (set draftset-quads))))))
+      (help/publish-quads-through-api handler quads)
+      (let [draftset-info (help/delete-quads-through-api handler test-editor draftset-location [(first graph-quads)])
+            draftset-quads (help/get-draftset-quads-through-api handler draftset-location test-editor "false")
+            expected-quads (help/eval-statements (rest graph-quads))]
+        (is (= #{live-graph} (tc/key-set (:changes draftset-info))))
+        (is (= (set expected-quads) (set draftset-quads)))))))
 
 (tc/deftest-system-with-keys delete-triples-from-graph-not-in-live
   keys-for-test

--- a/drafter/test/drafter/feature/draftset_data/test_helper.clj
+++ b/drafter/test/drafter/feature/draftset_data/test_helper.clj
@@ -6,13 +6,6 @@
 
 (t/use-fixtures :each tc/with-spec-instrumentation)
 
-(defn apply-job!
-  "Execute the job in this thread"
-  [{fun :function :as job}]
-  (let [ret (fun job)]
-    (t/is (= true ret)
-          "Successful job (returns true doesn't return an exception/error)")))
-
 (defn ensure-draftgraph-and-draftset-modified
   "Test that the draftgraph and draftset modified times match, and return the
    draftset modified time and version. NOTE that because a draftset contains

--- a/drafter/test/resources/drafter/routes/sparql-test/reasoning-start-state.trig
+++ b/drafter/test/resources/drafter/routes/sparql-test/reasoning-start-state.trig
@@ -9,6 +9,9 @@
 <http://publishmydata.com/graphs/drafter/drafts> {
   :PublicGraph a drafter:ManagedGraph ;
     drafter:isPublic true .
+
+  <http://publishmydata.com/graphs/reasoning-tbox> a drafter:ManagedGraph ;
+    drafter:isPublic true .
 }
 
 <http://publishmydata.com/graphs/reasoning-tbox> {


### PR DESCRIPTION
Issue #498 - Add StateMachine protocol which represents stepping
through each stage of a draftset data update operation. Rewrite the
append and delete jobs to implement this protocol. Add common
function to create update jobs from a state machine.

Add common function to read quads from the incoming request between
delete and append jobs.

Create ITripleReadable implementation which validates each quad
graph component is not a blank node and wrap incoming data sources
within append jobs.

Update the append and delete job functions to take explicit
parameters for the quad data source, draftset and job metadata to
separate them from the structure of the incoming job request.