### PR TITLE
Create interface for drafter operations

### DIFF
--- a/drafter/resources/drafter-base-config.edn
+++ b/drafter/resources/drafter-base-config.edn
@@ -45,6 +45,11 @@
 
  :drafter.time/system-clock {}
 
+ :drafter/manager {:drafter/backend #ig/ref :drafter/backend
+                   :drafter/global-writes-lock #ig/ref :drafter/global-writes-lock
+                   :drafter.time/clock #ig/ref :drafter.time/system-clock
+                   :drafter.backend.draftset.graphs/manager #ig/ref :drafter.backend.draftset.graphs/manager}
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
  ;; Web handlers
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -66,16 +71,13 @@
  :drafter.feature.draftset.show/handler {:drafter/backend #ig/ref :drafter/backend
                                          :wrap-auth #ig/ref :drafter.middleware/wrap-auth}
 
- :drafter.feature.draftset.create/handler {:drafter/backend #ig/ref :drafter/backend
-                                           :drafter/global-writes-lock #ig/ref :drafter/global-writes-lock
-                                           :drafter.time/clock #ig/ref :drafter.time/system-clock
+ :drafter.feature.draftset.create/handler {:drafter/manager #ig/ref :drafter/manager
                                            :wrap-auth #ig/ref :drafter.middleware/wrap-auth}
 
  :drafter.feature.middleware/wrap-as-draftset-owner {:drafter/backend #ig/ref :drafter/backend
                                                      :wrap-auth #ig/ref :drafter.middleware/wrap-auth}
 
  :drafter.feature.draftset.delete/handler {:drafter/backend #ig/ref :drafter/backend
-                                           :drafter/global-writes-lock #ig/ref :drafter/global-writes-lock
                                            :wrap-as-draftset-owner #ig/ref :drafter.feature.middleware/wrap-as-draftset-owner}
 
  :drafter.feature.draftset.options/handler {:drafter/backend #ig/ref :drafter/backend
@@ -85,69 +87,50 @@
                                               :wrap-as-draftset-owner #ig/ref :drafter.feature.middleware/wrap-as-draftset-owner
                                               :timeout-fn #ig/ref [:drafter.timeouts/timeout-query :drafter/draftset-timeout]}
 
- :drafter.feature.draftset-data.delete/delete-data-handler {:drafter/backend #ig/ref :drafter/backend
-                                                            :drafter/global-writes-lock #ig/ref :drafter/global-writes-lock
-                                                            :drafter.backend.draftset.graphs/manager #ig/ref :drafter.backend.draftset.graphs/manager
-                                                            :drafter.time/clock #ig/ref :drafter.time/system-clock
+ :drafter.feature.draftset-data.delete/delete-data-handler {:drafter/manager #ig/ref :drafter/manager
                                                             :wrap-as-draftset-owner #ig/ref :drafter.feature.middleware/wrap-as-draftset-owner}
 
  :drafter.feature.draftset-data.delete-by-graph/sync-job-handler
- {:backend #ig/ref :drafter/backend
-  :drafter.backend.draftset.graphs/manager #ig/ref :drafter.backend.draftset.graphs/manager
-  :global-writes-lock #ig/ref :drafter/global-writes-lock}
+ {:drafter/manager #ig/ref :drafter/manager}
 
  :drafter.feature.draftset-data.delete-by-graph/async-job-handler
- {:backend #ig/ref :drafter/backend
-  :drafter.backend.draftset.graphs/manager #ig/ref :drafter.backend.draftset.graphs/manager}
+ {:drafter/manager #ig/ref :drafter/manager}
 
  :drafter.feature.draftset-data.delete-by-graph/remove-graph-handler
- {:drafter/backend #ig/ref :drafter/backend
+ {:drafter/manager #ig/ref :drafter/manager
   :wrap-as-draftset-owner #ig/ref :drafter.feature.middleware/wrap-as-draftset-owner
   :sync-job-handler #ig/ref :drafter.feature.draftset-data.delete-by-graph/sync-job-handler
   :async-job-handler #ig/ref :drafter.feature.draftset-data.delete-by-graph/async-job-handler}
 
- :drafter.feature.draftset.changes/delete-changes-handler {:drafter/backend #ig/ref :drafter/backend
-                                                           :drafter/global-writes-lock #ig/ref :drafter/global-writes-lock
+ :drafter.feature.draftset.changes/delete-changes-handler {:drafter/manager #ig/ref :drafter/manager
                                                            :wrap-as-draftset-owner #ig/ref :drafter.feature.middleware/wrap-as-draftset-owner}
 
- :drafter.feature.draftset-data.append/data-handler {:drafter/backend #ig/ref :drafter/backend
-                                                     :drafter/global-writes-lock #ig/ref :drafter/global-writes-lock
-                                                     :drafter.backend.draftset.graphs/manager #ig/ref :drafter.backend.draftset.graphs/manager
-                                                     :drafter.time/clock #ig/ref :drafter.time/system-clock
+ :drafter.feature.draftset-data.append/data-handler {:drafter/manager #ig/ref :drafter/manager
                                                      :wrap-as-draftset-owner #ig/ref :drafter.feature.middleware/wrap-as-draftset-owner}
 
- :drafter.feature.draftset-data.append-by-graph/handler {:drafter/backend #ig/ref :drafter/backend
-                                                         :drafter/global-writes-lock #ig/ref :drafter/global-writes-lock
-                                                         :drafter.backend.draftset.graphs/manager #ig/ref :drafter.backend.draftset.graphs/manager
-                                                         :drafter.time/clock #ig/ref :drafter.time/system-clock
+ :drafter.feature.draftset-data.append-by-graph/handler {:drafter/manager #ig/ref :drafter/manager
                                                          :wrap-as-draftset-owner #ig/ref :drafter.feature.middleware/wrap-as-draftset-owner}
 
  :drafter.feature.draftset.query/handler {:drafter/backend #ig/ref :drafter/backend
                                           :wrap-as-draftset-owner #ig/ref :drafter.feature.middleware/wrap-as-draftset-owner
                                           :timeout-fn #ig/ref [:drafter.timeouts/timeout-query :drafter/draftset-timeout]}
 
- :drafter.feature.draftset.update/handler {:drafter/backend #ig/ref :drafter/backend
-                                           :drafter.backend.draftset.graphs/manager #ig/ref :drafter.backend.draftset.graphs/manager
-                                           :drafter.time/clock #ig/ref :drafter.time/system-clock
+ :drafter.feature.draftset.update/handler {:drafter/manager #ig/ref :drafter/manager
                                            :wrap-as-draftset-owner #ig/ref :drafter.feature.middleware/wrap-as-draftset-owner
                                            :max-update-size 5000}
 
- :drafter.feature.draftset.publish/handler {:drafter/backend #ig/ref :drafter/backend
-                                            :drafter.time/clock #ig/ref :drafter.time/system-clock
+ :drafter.feature.draftset.publish/handler {:drafter/manager #ig/ref :drafter/manager
                                             :wrap-as-draftset-owner #ig/ref :drafter.feature.middleware/wrap-as-draftset-owner}
 
- :drafter.feature.draftset.set-metadata/handler {:drafter/backend #ig/ref :drafter/backend
-                                                 :drafter/global-writes-lock #ig/ref :drafter/global-writes-lock
+ :drafter.feature.draftset.set-metadata/handler {:drafter/manager #ig/ref :drafter/manager
                                                  :wrap-as-draftset-owner #ig/ref :drafter.feature.middleware/wrap-as-draftset-owner}
 
- :drafter.feature.draftset.submit/handler {:drafter/backend #ig/ref :drafter/backend
-                                           :drafter/global-writes-lock #ig/ref :drafter/global-writes-lock
+ :drafter.feature.draftset.submit/handler {:drafter/manager #ig/ref :drafter/manager
                                            :drafter.user/repo #ig/ref :drafter.user/repo
                                            :wrap-as-draftset-owner #ig/ref :drafter.feature.middleware/wrap-as-draftset-owner}
 
  :drafter.feature.draftset.claim/handler {:wrap-auth #ig/ref :drafter.middleware/wrap-auth
-                                          :drafter/global-writes-lock #ig/ref :drafter/global-writes-lock
-                                          :drafter/backend #ig/ref :drafter/backend}
+                                          :drafter/manager #ig/ref :drafter/manager}
 
  #_:drafter.routes.draftsets-api/get-users-handler
  :drafter.feature.users.list/get-users-handler {:wrap-auth #ig/ref :drafter.middleware/wrap-auth

--- a/drafter/src/drafter/async/jobs.clj
+++ b/drafter/src/drafter/async/jobs.clj
@@ -12,7 +12,8 @@
             [integrant.core :as ig])
   (:import clojure.lang.ExceptionInfo
            java.util.UUID
-           org.apache.log4j.MDC))
+           org.apache.log4j.MDC
+           [clojure.lang IDeref IBlockingDeref IPersistentMap]))
 
 (defrecord Job [id
                 user-id
@@ -24,7 +25,16 @@
                 draft-graph-id
                 metadata
                 function
-                value-p])
+                value-p]
+  IDeref
+  (deref [_] (deref value-p))
+
+  IBlockingDeref
+  (deref [_ timeout-ms timeout-val] (deref value-p timeout-ms timeout-val)))
+
+(defmethod print-method Job [job writer]
+  (let [m (get-method print-method IPersistentMap)]
+    (m job writer)))
 
 (def allowed-queue-keys
   #{:id :user-id :status :priority :start-time :finish-time

--- a/drafter/src/drafter/async/responses.clj
+++ b/drafter/src/drafter/async/responses.clj
@@ -44,16 +44,13 @@
    (json-response code (assoc default-response-map :details map))))
 
 (s/fdef submitted-job-response
-  :args (s/or :ary-1 (s/cat :job ::async/job)
-              :ary-2 (s/cat :prefix-path string? :job ::async/job))
+  :args (s/cat :job ::async/job)
   :ret :submitted-job/response)
 
-(defn submitted-job-response
-  ([job] (submitted-job-response "" job))
-  ([prefix-path {:keys [id] :as job}]
-   (json-response 202 {:type :ok
-                       :finished-job (format "/v1/status/finished-jobs/%s" id)
-                       :restart-id restart-id})))
+(defn submitted-job-response [{:keys [id] :as job}]
+  (json-response 202 {:type         :ok
+                      :finished-job (format "/v1/status/finished-jobs/%s" id)
+                      :restart-id   restart-id}))
 
 (s/fdef job-not-finished-response
   :args (s/cat :restart-id ::async/restart-id)

--- a/drafter/src/drafter/backend.clj
+++ b/drafter/src/drafter/backend.clj
@@ -24,7 +24,7 @@
 ;; client etc...
 (defrecord DrafterService [repo]
   repo/ToConnection
-  (repo/->connection [this]
+  (->connection [_this]
     ;; Note calling ->connection on DrafterService returns an
     ;; unrestricted endpoint, that has access to the state graph
     ;; and can perform updates etc...

--- a/drafter/src/drafter/backend/draftset.clj
+++ b/drafter/src/drafter/backend/draftset.clj
@@ -84,7 +84,7 @@
 
 (defn build-draftset-endpoint
   "Build a SPARQL queryable repo representing the draftset"
-  [{:keys [repo]} draftset-ref union-with-live?]
+  [repo draftset-ref union-with-live?]
   (let [graph-mapping (dsmgmt/get-draftset-graph-mapping repo draftset-ref)]
     (->RewritingSesameSparqlExecutor repo graph-mapping union-with-live?)))
 

--- a/drafter/src/drafter/backend/draftset/graphs/spec.clj
+++ b/drafter/src/drafter/backend/draftset/graphs/spec.clj
@@ -1,0 +1,15 @@
+(ns drafter.backend.draftset.graphs.spec
+  (:require [clojure.spec.alpha :as s]
+            [drafter.backend :as backend]
+            [drafter.backend.spec]
+            [drafter.backend.draftset.graphs :as graphs]
+            [drafter.time :as time]
+            [drafter.time.spec]))
+
+(s/def ::graphs/URIMatcher #(satisfies? graphs/URIMatcher %))
+
+(s/def ::graphs/protected-graphs (s/coll-of ::graphs/URIMatcher :kind set?))
+
+(s/def ::graphs/Manager (s/keys :req-un [::backend/repo
+                                         ::graphs/protected-graphs
+                                         ::time/clock]))

--- a/drafter/src/drafter/backend/live.clj
+++ b/drafter/src/drafter/backend/live.clj
@@ -11,7 +11,7 @@
   (:import [java.io Closeable]
            [org.eclipse.rdf4j.query Query]))
 
-(defn- build-restricted-connection [{:keys [inner restriction]}]
+(defn- build-restricted-connection [inner restriction]
   (let [stasher-conn (repo/->connection inner)]
     (reify
       repo/IPrepareQuery
@@ -44,13 +44,13 @@
 
 (defrecord RestrictedExecutor [inner restriction]
   repo/ToConnection
-  (->connection [this]
-    (build-restricted-connection this)))
+  (->connection [_this]
+    (build-restricted-connection inner restriction)))
 
 (defn live-endpoint-with-stasher
   "Creates a backend restricted to the live graphs."
-  [{:keys [repo]}]
+  [repo]
   (->RestrictedExecutor repo (partial mgmt/live-graphs repo)))
 
-(defmethod ig/init-key ::endpoint [_ opts]
-  (live-endpoint-with-stasher opts))
+(defmethod ig/init-key ::endpoint [_ {:keys [repo] :as opts}]
+  (live-endpoint-with-stasher repo))

--- a/drafter/src/drafter/backend/spec.clj
+++ b/drafter/src/drafter/backend/spec.clj
@@ -17,14 +17,10 @@
 (s/def ::backend/repo (s/with-gen #(satisfies? repo/ToConnection %)
                           (fn [] (gen/return (repo/sail-repo)))))
 
-(s/def ::backend/DraftsetGraphMapping (s/map-of uri? uri?))
-
 (defmethod ig/pre-init-spec :drafter/backend [_]
   (s/keys :req-un [::backend/repo]))
 
+(s/def ::backend/DraftsetGraphMapping (s/map-of uri? uri?))
+
 (defmethod ig/pre-init-spec ::live/endpoint [_]
   (s/keys :req-un [::backend/repo]))
-
-(defmethod ig/pre-init-spec ::draftset/endpoint [_]
-  (s/keys :req-un [::backend/repo]))
-

--- a/drafter/src/drafter/feature/draftset/changes.clj
+++ b/drafter/src/drafter/feature/draftset/changes.clj
@@ -27,13 +27,13 @@
     :not-found))
 
 (defn delete-draftset-changes-handler
-  [{:keys [:drafter/backend :drafter/global-writes-lock wrap-as-draftset-owner]}]
+  [{:keys [wrap-as-draftset-owner] {:keys [backend] :as manager} :drafter/manager}]
   (wrap-as-draftset-owner
    (middleware/parse-graph-param-handler
     true
     (fn [{{:keys [draftset-id graph]} :params :as request}]
       (feat-common/run-sync
-       {:backend backend :global-writes-lock global-writes-lock}
+       manager
        (req/user-id request)
        'delete-draftset-changes
        draftset-id
@@ -46,7 +46,7 @@
              (ring/not-found "")))))))))
 
 (defmethod ig/pre-init-spec :drafter.feature.draftset.changes/delete-changes-handler [_]
-  (s/keys :req [:drafter/backend :drafter/global-writes-lock]
+  (s/keys :req [:drafter/manager]
           :req-un [::wrap-as-draftset-owner]))
 
 (defmethod ig/init-key :drafter.feature.draftset.changes/delete-changes-handler [_ opts]

--- a/drafter/src/drafter/feature/draftset/create.clj
+++ b/drafter/src/drafter/feature/draftset/create.clj
@@ -7,12 +7,11 @@
             [drafter.util :as util]
             [ring.util.response :as ring]
             [drafter.async.responses :as response]
-            [drafter.requests :as req]
-            [drafter.time :as time]))
+            [drafter.requests :as req]))
 
 (defn create-draftsets-handler
   [{wrap-authenticated :wrap-auth
-    :keys [:drafter/backend :drafter/global-writes-lock ::time/clock]}]
+    {:keys [backend global-writes-lock clock] :as manager} :drafter/manager}]
   (let [version "/v1"]
     (wrap-authenticated
      (fn [{{:keys [display-name description]} :params user :identity :as request}]
@@ -31,7 +30,7 @@
 (s/def ::wrap-auth fn?)
 
 (defmethod ig/pre-init-spec :drafter.feature.draftset.create/handler [_]
-  (s/keys :req [:drafter/backend :drafter/global-writes-lock ::time/clock]
+  (s/keys :req [:drafter/manager]
           :req-un [::wrap-auth]))
 
 (defmethod ig/init-key ::handler [_ opts]

--- a/drafter/src/drafter/feature/draftset/publish.clj
+++ b/drafter/src/drafter/feature/draftset/publish.clj
@@ -4,23 +4,21 @@
             [drafter.responses :refer [forbidden-response submit-async-job!]]
             [drafter.user :as user]
             [integrant.core :as ig]
-            [drafter.requests :as req]
-            [drafter.time :as time]))
+            [drafter.requests :as req]))
 
 (defn handler
-  [{backend :drafter/backend :keys [wrap-as-draftset-owner ::time/clock]}]
+  [{manager :drafter/manager :keys [wrap-as-draftset-owner]}]
   (wrap-as-draftset-owner
    (fn [{params :params user :identity :as request}]
      (if (user/has-role? user :publisher)
        (submit-async-job!
-        (dsjobs/publish-draftset-job backend
+        (dsjobs/publish-draftset-job manager
                                      (req/user-id request)
-                                     params
-                                     clock))
+                                     params))
        (forbidden-response "You require the publisher role to perform this action")))))
 
 (defmethod ig/pre-init-spec :drafter.feature.draftset.publish/handler [_]
-  (s/keys :req [:drafter/backend]
+  (s/keys :req [:drafter/manager]
           :req-un [::wrap-as-draftset-owner]))
 
 (defmethod ig/init-key :drafter.feature.draftset.publish/handler [_ opts]

--- a/drafter/src/drafter/feature/draftset/set_metadata.clj
+++ b/drafter/src/drafter/feature/draftset/set_metadata.clj
@@ -6,11 +6,11 @@
             [drafter.requests :as req]))
 
 (defn handler
-  [{:keys [:drafter/backend :drafter/global-writes-lock wrap-as-draftset-owner timeout-fn]}]
+  [{:keys [wrap-as-draftset-owner] {:keys [backend] :as manager} :drafter/manager}]
   (wrap-as-draftset-owner
    (fn [{{:keys [draftset-id] :as params} :params :as request}]
      (feat-common/run-sync
-      {:backend backend :global-writes-lock global-writes-lock}
+      manager
       (req/user-id request)
       'set-draftset-metadata
       draftset-id
@@ -18,7 +18,7 @@
       #(feat-common/draftset-sync-write-response % backend draftset-id)))))
 
 (defmethod ig/pre-init-spec :drafter.feature.draftset.set-metadata/handler [_]
-  (s/keys :req [:drafter/backend :drafter/global-writes-lock]
+  (s/keys :req [:drafter/manager]
           :req-un [::wrap-as-draftset-owner]))
 
 (defmethod ig/init-key :drafter.feature.draftset.set-metadata/handler [_ opts]

--- a/drafter/src/drafter/feature/draftset/submit.clj
+++ b/drafter/src/drafter/feature/draftset/submit.clj
@@ -7,52 +7,50 @@
             [integrant.core :as ig]))
 
 (defn handle-user
-  [{:keys [backend] :as resources} repo user draftset-id owner]
+  [{:keys [backend] :as manager} repo user draftset-id owner]
   (if-let [target-user (user/find-user-by-username repo user)]
     (feat-common/run-sync
-     resources
-     (:email owner)
-     'submit-draftset-to-user
-     draftset-id
-     #(dsops/submit-draftset-to-user! backend draftset-id owner target-user)
-     #(feat-common/draftset-sync-write-response % backend draftset-id))
+      manager
+      (:email owner)
+      'submit-draftset-to-user
+      draftset-id
+      #(dsops/submit-draftset-to-user! backend draftset-id owner target-user)
+      #(feat-common/draftset-sync-write-response % backend draftset-id))
     (unprocessable-entity-response (str "User: " user " not found"))))
 
 (defn handle-role
-  [{:keys [backend] :as resources} role draftset-id owner]
+  [{:keys [backend] :as manager} role draftset-id owner]
   (let [role-kw (keyword role)]
     (if (user/is-known-role? role-kw)
       (feat-common/run-sync
-       resources
-       (:email owner)
-       'submit-draftset-to-role
-       draftset-id
-       #(dsops/submit-draftset-to-role! backend draftset-id owner role-kw)
-       #(feat-common/draftset-sync-write-response % backend draftset-id))
+        manager
+        (:email owner)
+        'submit-draftset-to-role
+        draftset-id
+        #(dsops/submit-draftset-to-role! backend draftset-id owner role-kw)
+        #(feat-common/draftset-sync-write-response % backend draftset-id))
       (unprocessable-entity-response (str "Invalid role: " role)))))
 
 (defn handler
-  [{:keys [:drafter/backend :drafter/global-writes-lock :drafter.user/repo
-           wrap-as-draftset-owner timeout-fn]}]
-  (let [resources {:backend backend :global-writes-lock global-writes-lock}]
-    (wrap-as-draftset-owner
-     (fn [{{:keys [user role draftset-id]} :params owner :identity}]
-       (cond
-         (and (some? user) (some? role))
-         (unprocessable-entity-response
+  [{:keys [:drafter/manager :drafter.user/repo wrap-as-draftset-owner]}]
+  (wrap-as-draftset-owner
+    (fn [{{:keys [user role draftset-id]} :params owner :identity}]
+      (cond
+        (and (some? user) (some? role))
+        (unprocessable-entity-response
           "Only one of user and role parameters permitted")
 
-         (some? user)
-         (handle-user resources repo user draftset-id owner)
+        (some? user)
+        (handle-user manager repo user draftset-id owner)
 
-         (some? role)
-         (handle-role resources role draftset-id owner)
+        (some? role)
+        (handle-role manager role draftset-id owner)
 
-         :else
-         (unprocessable-entity-response "user or role parameter required"))))))
+        :else
+        (unprocessable-entity-response "user or role parameter required")))))
 
 (defmethod ig/pre-init-spec :drafter.feature.draftset.submit/handler [_]
-  (s/keys :req [:drafter/backend :drafter/global-writes-lock ::user/repo]
+  (s/keys :req [:drafter/manager ::user/repo]
           :req-un [::wrap-as-draftset-owner]))
 
 (defmethod ig/init-key :drafter.feature.draftset.submit/handler [_ opts]

--- a/drafter/src/drafter/feature/draftset/update.clj
+++ b/drafter/src/drafter/feature/draftset/update.clj
@@ -378,7 +378,7 @@ GROUP BY ?lg ?dg ?public")))
   (let [ops (mapcat (fn [op] (reify-operation op update-context)) operations)]
     (jena/->update-string ops)))
 
-(defn- update! [backend graph-manager clock max-update-size draftset-id ^UpdateRequest update-request]
+(defn update! [{:keys [backend graph-manager clock] :as manager} max-update-size draftset-id ^UpdateRequest update-request]
   (let [graph-meta (get-graph-meta backend draftset-id update-request)
         update-plan (plan-update (.getOperations update-request) graph-meta max-update-size)
 
@@ -418,27 +418,19 @@ GROUP BY ?lg ?dg ?public")))
       (throw (ex-info "Parameter draftset-id must be provided"
                       {:error :bad-request}))))
 
-(defn- protected? [{:keys [drafter.backend.draftset.graphs/manager] :as opts} op]
-  (some (partial graphs/protected-graph? manager) (affected-graphs op)))
+(defn- protected? [{:keys [graph-manager] :as manager} op]
+  (some (partial graphs/protected-graph? graph-manager) (affected-graphs op)))
 
 (defn- ^UpdateRequest parse-update-string [^String update-string]
   (UpdateFactory/create update-string Syntax/syntaxSPARQL_11))
 
-(defn- parse-update-param [opts {:keys [update from]} max-update-size]
-  (let [update' (cond (string? update)
-                      update
-                      (instance? java.io.InputStream update)
-                      (slurp update)
-                      (coll? update)
-                      (throw (ex-info "Exactly one query parameter required"
-                                      {:error :unprocessable-request}))
-                      :else
-                      (throw (ex-info (str "Expected SPARQL query in " from)
-                                      {:error :unprocessable-request})))
-        update-request (parse-update-string update')
+(defn parse-update-query
+  "Parses and validates an UPDATE query string. Return the parsed query representation."
+  [manager update-query-string max-update-size]
+  (let [update-request (parse-update-string update-query-string)
         operations (.getOperations update-request)
         unprocessable (remove processable? operations)]
-    (cond (some (partial protected? opts) operations)
+    (cond (some (partial protected? manager) operations)
           (throw (forbidden-request "Protected graphs in update request"))
           (seq unprocessable)
           (throw (unprocessable-request unprocessable))
@@ -446,6 +438,20 @@ GROUP BY ?lg ?dg ?public")))
           (throw (payload-too-large operations))
           :else
           update-request)))
+
+(defn- get-update-query
+  "Extracts an UPDATE query string from a representation of the input request parameters"
+  [{:keys [update from]}]
+  (cond (string? update)
+        update
+        (instance? java.io.InputStream update)
+        (slurp update)
+        (coll? update)
+        (throw (ex-info "Exactly one query parameter required"
+                        {:error :unprocessable-request}))
+        :else
+        (throw (ex-info (str "Expected SPARQL query in " from)
+                        {:error :unprocessable-request}))))
 
 #_(defn- prepare-update [backend request]
   ;; NOTE: Currently unused. None of the Update types that we have implemented
@@ -459,21 +465,22 @@ GROUP BY ?lg ?dg ?public")))
       (doto (.prepareUpdate repo (:update params))
         (.setDataset dataset)))))
 
-(defn- parse-update [opts request max-update-size]
-  (let [{:keys [request-method body query-params form-params]} request]
+(defn- parse-update [manager request max-update-size]
+  (let [{:keys [request-method]} request]
     (if (= request-method :post)
       (let [draftset-id (parse-draftset-id request)
             params (parse-update-params request)
-            update-request (parse-update-param opts params max-update-size)]
+            update-query (get-update-query params)
+            update-request (parse-update-query manager update-query max-update-size)]
         (assoc params :update-request update-request :draftset-id draftset-id))
       (throw (ex-info "Method not supported"
                       {:error :method-not-allowed :method request-method})))))
 
 (defn- handler*
-  [{:keys [drafter/backend drafter.backend.draftset.graphs/manager max-update-size ::time/clock] :as opts} request]
+  [{:keys [drafter/manager max-update-size] :as opts} request]
   ;; TODO: write-lock?
-  (let [{:keys [update-request draftset-id]} (parse-update opts request max-update-size)]
-    (update! backend manager clock max-update-size draftset-id update-request)
+  (let [{:keys [update-request draftset-id]} (parse-update manager request max-update-size)]
+    (update! manager max-update-size draftset-id update-request)
     {:status 204}))
 
 (defn handler

--- a/drafter/src/drafter/feature/draftset/update/spec.clj
+++ b/drafter/src/drafter/feature/draftset/update/spec.clj
@@ -7,6 +7,8 @@
             [drafter.draftset.spec]
             [drafter.rdf.jena :as jena]
             [drafter.rdf.jena.spec]
+            [drafter.manager :as manager]
+            [drafter.manager.spec]
             [integrant.core :as ig]))
 
 (s/def ::update/UpdateOperation #(satisfies? update/UpdateOperation %))
@@ -105,6 +107,6 @@
 
 ;; handler
 (defmethod ig/pre-init-spec ::update/handler [_]
-  (s/keys :req [:drafter/backend]
+  (s/keys :req [:drafter/manager]
           :req-un [::wrap-as-draftset-owner ::max-update-size]))
 

--- a/drafter/src/drafter/manager.clj
+++ b/drafter/src/drafter/manager.clj
@@ -1,0 +1,20 @@
+(ns drafter.manager
+  (:require [integrant.core :as ig]
+            [drafter.backend.draftset.graphs :as graphs]
+            [drafter.write-scheduler :as writes]
+            [drafter.time :as time]))
+
+(defn create-manager
+  ([repo] (create-manager repo {}))
+  ([repo {:keys [clock graph-manager global-writes-lock] :as opts}]
+   (let [clock (or clock time/system-clock)
+         graph-manager (or graph-manager (graphs/create-manager repo #{} clock))
+         global-writes-lock (or global-writes-lock (writes/create-writes-lock))]
+     {:backend repo :global-writes-lock global-writes-lock :graph-manager graph-manager :clock clock})))
+
+(defmethod ig/init-key :drafter/manager [_ {:keys [drafter/backend
+                                                   drafter/global-writes-lock
+                                                   drafter.time/clock
+                                                   ::graphs/manager] :as opts}]
+  (create-manager backend {:clock clock :graph-manager manager :global-writes-lock global-writes-lock}))
+

--- a/drafter/src/drafter/manager/spec.clj
+++ b/drafter/src/drafter/manager/spec.clj
@@ -1,0 +1,27 @@
+(ns drafter.manager.spec
+  (:require [drafter.manager :as manager]
+            [drafter.time :as time]
+            [drafter.time.spec]
+            [drafter.backend.draftset.graphs :as graphs]
+            [drafter.backend.draftset.graphs.spec]
+            [drafter.backend :as backend]
+            [drafter.backend.spec]
+            [drafter.write-scheduler :as write-scheduler]
+            [drafter.write-scheduler.spec]
+            [clojure.spec.alpha :as s]))
+
+(s/def ::manager/backend ::backend/repo)
+(s/def ::manager/graph-manager ::graphs/Manager)
+(s/def ::manager/global-writes-lock ::write-scheduler/WritesLock)
+
+(s/def :drafter/manager (s/keys :req-un [::manager/backend
+                                         ::manager/graph-manager
+                                         ::manager/global-writes-lock
+                                         ::time/clock]))
+
+(s/fdef manager/create-manager
+  :args (s/alt :default (s/cat :repo ::backend/repo)
+               :opts (s/cat :repo ::backend/repo :opts (s/keys :opt-un [::manager/graph-manager
+                                                                        ::manager/global-writes-lock
+                                                                        ::time/clock])))
+  :ret :drafter/manager)

--- a/drafter/src/drafter/rdf/draftset_management/jobs.clj
+++ b/drafter/src/drafter/rdf/draftset_management/jobs.clj
@@ -15,7 +15,7 @@
 (defn publish-draftset-job
   "Return a job that publishes the graphs in a draftset to live and
   then deletes the draftset."
-  [backend user-id {:keys [draftset-id metadata]} clock]
+  [{:keys [backend clock] :as manager} user-id {:keys [draftset-id metadata]}]
   ;; TODO combine these into a single job as priorities have now
   ;; changed how these will be applied.
 

--- a/drafter/src/drafter/spec.clj
+++ b/drafter/src/drafter/spec.clj
@@ -21,12 +21,15 @@
     drafter.async.spec
     drafter.backend.spec
     drafter.backend.draftset.spec
+    drafter.backend.draftset.graphs.spec
     drafter.draftset.spec
     drafter.endpoint.spec
     drafter.user.spec
     drafter.time.spec
     drafter.rdf.jena.spec
-    drafter.feature.draftset.update.spec])
+    drafter.feature.draftset.update.spec
+    drafter.manager.spec
+    drafter.write-scheduler.spec])
 
 (defn load-spec-namespaces! []
   (doseq [ns spec-namespaces]

--- a/drafter/src/drafter/write_scheduler/spec.clj
+++ b/drafter/src/drafter/write_scheduler/spec.clj
@@ -1,0 +1,28 @@
+(ns drafter.write-scheduler.spec
+  (:require [clojure.spec.alpha :as s]
+            [drafter.write-scheduler :as write-scheduler]
+            [integrant.core :as ig])
+  (:import [java.util.concurrent TimeUnit]
+           [java.util.concurrent.locks ReentrantLock]))
+
+(s/def :named/unit (set (keys write-scheduler/timeunit)))
+(s/def :java/unit #(instance? TimeUnit %))
+
+(s/def ::write-scheduler/lock #(instance? ReentrantLock %))
+(s/def ::write-scheduler/time pos-int?)
+(s/def ::write-scheduler/unit :java/unit)
+(s/def ::write-scheduler/fairness boolean?)
+
+(s/def ::write-scheduler/WritesLock (s/keys :req-un [::write-scheduler/lock
+                                                     ::write-scheduler/time
+                                                     :java/unit]))
+
+(defmethod ig/pre-init-spec :drafter/write-scheduler [_]
+  (s/keys :req [:drafter/global-writes-lock]))
+
+(s/fdef write-scheduler/create-writes-lock
+  :args (s/alt :default (s/cat)
+               :opts (s/keys :opt-un [::write-scheduler/fairness
+                                      ::write-scheduler/time
+                                      :named/unit]))
+  :ret ::write-scheduler/WritesLock)

--- a/drafter/test/drafter/feature/draftset_data/delete_test.clj
+++ b/drafter/test/drafter/feature/draftset_data/delete_test.clj
@@ -18,7 +18,8 @@
             [grafter.vocabularies.rdf :refer [rdf:a]]
             [grafter.vocabularies.dcterms :refer [dcterms:issued dcterms:modified]]
             [drafter.feature.endpoint.public :as pub]
-            [drafter.rdf.sesame :as ses])
+            [drafter.rdf.sesame :as ses]
+            [drafter.manager :as manager])
   (:import java.net.URI
            java.time.OffsetDateTime
            org.eclipse.rdf4j.rio.RDFFormat))
@@ -37,17 +38,16 @@
   (tc/with-system
     [:drafter/backend :drafter/global-writes-lock :drafter/write-scheduler :drafter.fixture-data/loader
      :drafter.backend.draftset.graphs/manager]
-    [{:keys [:drafter/backend :drafter/global-writes-lock :drafter.backend.draftset.graphs/manager]} system-config]
+    [{:keys [:drafter/backend]} system-config]
     (let [initial-time (OffsetDateTime/parse "2017-01-01T01:01:01Z")
           delete-time (OffsetDateTime/parse "2019-01-01T01:01:01Z")
           clock (tc/manual-clock initial-time)
           ds (dsops/create-draftset! backend test-editor)
-          resources {:backend backend :global-writes-lock global-writes-lock :graph-manager manager}
-          append-job (append/append-data-to-draftset-job (get-source (io/file "./test/test-triple.nt") (URI. "http://foo/graph"))
-                                                         resources
+          manager (manager/create-manager backend {:clock clock})
+          append-job (append/append-data-to-draftset-job manager
                                                          dummy
                                                          ds
-                                                         clock
+                                                         (get-source (io/file "./test/test-triple.nt") (URI. "http://foo/graph"))
                                                          nil)]
       (tc/exec-and-await-job-success append-job)
       (tc/set-now clock delete-time)
@@ -56,12 +56,11 @@
                         ds
                         "http://foo/graph")
             delete-job (sut/delete-data-from-draftset-job
+                        manager
+                        dummy
+                        ds
                         (get-source (io/file "./test/test-triple-2.nt")
                                     (URI. "http://foo/graph"))
-                        dummy
-                        resources
-                        ds
-                        clock
                         nil)
             _  (tc/exec-and-await-job-success delete-job)
             modified-2 (th/ensure-draftgraph-and-draftset-modified

--- a/drafter/test/drafter/model.clj
+++ b/drafter/test/drafter/model.clj
@@ -1,0 +1,388 @@
+(ns drafter.model
+  "Defines an interface for all test drafter operations and contains an implementation which invokes handler
+   operations directly instead of going via the ring API. Also contains a make-sync function which converts all
+   asynchronous operations into ones which block waiting for inner operations to complete."
+  (:require [clojure.test :refer :all]
+            [drafter.backend.draftset.operations :as dsops]
+            [drafter.feature.draftset.list :as ds-list]
+            [drafter.feature.draftset.changes :as ds-changes]
+            [drafter.feature.draftset.show :as ds-show]
+            [drafter.feature.draftset-data.append :as ds-append]
+            [drafter.feature.draftset-data.append-by-graph :as ds-append-by-graph]
+            [drafter.feature.draftset-data.delete-by-graph :as ds-delete-by-graph]
+            [drafter.feature.draftset-data.delete :as ds-delete]
+            [drafter.user :as user]
+            [drafter.util :as util]
+            [drafter.backend :as backend]
+            [grafter-2.rdf.protocols :as pr]
+            [drafter.backend.draftset.graphs :as graphs]
+            [drafter.backend.draftset :as draftsets]
+            [grafter-2.rdf4j.repository :as repo]
+            [clojure.test :as t]
+            [drafter.test-common :as tc]
+            [drafter.user-test :refer [test-publisher test-editor]]
+            [drafter.rdf.sesame :as ses]
+            [drafter.responses :as responses]
+            [drafter.rdf.draftset-management.jobs :as dsjobs]
+            [martian.encoders :as enc]
+            [drafter.write-scheduler :as writes]
+            [drafter.feature.draftset.update :as update]
+            [drafter.write-scheduler :as write-scheduler]
+            [drafter.time :as time])
+  (:import [java.time OffsetDateTime ZoneOffset]
+           [java.net URI]
+           [clojure.lang ExceptionInfo]
+           [java.lang AutoCloseable]))
+
+(defn- format-metadata [metadata]
+  (some-> metadata enc/json-encode))
+
+(defn- create-draftset-op [{:keys [backend clock] :as drafter} user {:keys [display-name description id] :as opts}]
+  (let [id-fn (if (some? id) (constantly id) util/create-uuid)]
+    (dsops/create-draftset! backend user display-name description id-fn clock)))
+
+(defn- revert-draftset-graph-changes-op [{:keys [backend] :as drafter} _user draftset-ref graph-uri]
+  (let [result (ds-changes/revert-graph-changes! backend draftset-ref graph-uri)]
+    (case result
+      :reverted (dsops/get-draftset-info backend draftset-ref)
+      :not-found (throw (ex-info (format "Graph %s not found" graph-uri)
+                                 {:graph graph-uri :draftset draftset-ref}))
+      (throw (ex-info "Unexpected revert result" {:result result})))))
+
+(defn- claim-draftset-op [{:keys [backend] :as drafter} user draftset-ref]
+  (if-let [ds-info (dsops/get-draftset-info backend draftset-ref)]
+    (if (user/can-claim? user ds-info)
+      (let [[outcome ds-info] (dsops/claim-draftset! backend draftset-ref user)]
+        (if (= :ok outcome)
+          ds-info
+          (throw (ex-info "Failed to claim draftset" {}))))
+      (throw (ex-info "User cannot claim draftset" {})))
+    (throw (ex-info "Draftset not found" {}))))
+
+(defn- delete-draftset-op [{:keys [backend] :as drafter} user draftset-ref {:keys [metadata] :as opts}]
+  (let [params (cond-> {:draftset-id draftset-ref}
+                       (some? metadata) (assoc :metadata (format-metadata metadata)))
+        job (dsjobs/delete-draftset-job backend
+                                        user
+                                        params)]
+    (responses/enqueue-async-job! job)))
+
+(defn- list-draftsets-op [{:keys [backend] :as drafter} user {:keys [include union-with-live?] :as opts}]
+  (ds-list/get-draftsets backend user (or include :all) (or union-with-live? false)))
+
+(defn- draftset-options-op [{:keys [backend] :as drafter} user draftset-ref]
+  (dsops/find-permitted-draftset-operations backend draftset-ref user))
+
+(defn- publish-draftset-op [drafter user draftset-ref {:keys [metadata] :as opts}]
+  (if (user/has-role? user :publisher)
+    (let [params (cond-> {:draftset-id draftset-ref}
+                         (some? metadata) (assoc :metadata (format-metadata metadata)))
+          job (dsjobs/publish-draftset-job drafter
+                                           user
+                                           params)]
+      (responses/enqueue-async-job! job))
+    (throw (ex-info "You require the publisher role to perform this action" {}))))
+
+(defn- draftset-query-endpoint-op [{:keys [backend]} _user draftset-ref {:keys [union-with-live?] :as opts}]
+  (backend/endpoint-repo backend draftset-ref {:union-with-live? union-with-live?}))
+
+(defn- set-draftset-metadata-op [{:keys [backend] :as drafter} _user draftset-ref metadata]
+  (dsops/set-draftset-metadata! backend draftset-ref metadata)
+  (dsops/get-draftset-info backend draftset-ref))
+
+(defn- show-draftset-op [{:keys [backend] :as drafter} user draftset-ref {:keys [union-with-live?] :as opts}]
+  (ds-show/get-draftset backend user draftset-ref (or union-with-live? false)))
+
+(defn- submit-draftset-op [{:keys [backend]} user draftset-ref {target-user :user target-role :role :as opts}]
+  (cond
+    (and (some? target-user) (some? target-role)) (throw (ex-info "Specify only one of target user or role" {}))
+    (some? target-user) (dsops/submit-draftset-to-user! backend draftset-ref user target-user)
+    (some? target-role) (dsops/submit-draftset-to-role! backend draftset-ref user target-role)
+    :else (throw (ex-info "Target user or role required" {})))
+  (dsops/get-draftset-info backend draftset-ref))
+
+(defn- append-draftset-data-op [drafter user draftset-ref source {:keys [metadata] :as opts}]
+  (ds-append/append-data drafter user draftset-ref source (format-metadata metadata)))
+
+(defn- copy-live-graph-into-draftset-op [drafter user draftset-ref graph {:keys [metadata] :as opts}]
+  (ds-append-by-graph/copy-live-graph drafter user draftset-ref graph metadata))
+
+(defn- delete-draftset-data-op [drafter user draftset-ref source {:keys [metadata] :as opts}]
+  (ds-delete/delete-data drafter user draftset-ref source metadata))
+
+(defn- delete-draftset-graph-op [drafter user draftset-ref graph {:keys [silent] :as opts}]
+  (ds-delete-by-graph/delete-graph drafter user draftset-ref graph (or silent false)))
+
+(defn- get-draftset-data-op [{:keys [backend] :as drafter} _user draftset-ref {:keys [graph union-with-live?]}]
+  (let [union-with-live? (or union-with-live? false)
+        executor (draftsets/build-draftset-endpoint backend draftset-ref union-with-live?)
+        is-triples-query? (some? graph)
+        pquery (if is-triples-query?
+                 (dsops/all-graph-triples-query executor graph)
+                 (dsops/all-quads-query executor))]
+    (repo/evaluate pquery)))
+
+(defn- live-query-endpoint-op [{:keys [backend] :as drafter}]
+  (backend/endpoint-repo backend ::backend/live))
+
+(defn- get-setting [drafter setting]
+  (get-in drafter [:settings setting]))
+
+(defn- submit-update-request-op [drafter user draftset-ref update-query]
+  (let [max-update-size (get-setting drafter :max-update-size)
+        update (update/parse-update-query drafter update-query max-update-size)]
+    (update/update! drafter max-update-size draftset-ref update)))
+
+(defrecord ModelDrafter [backend clock graph-manager global-writes-lock writes-handle operations settings]
+  AutoCloseable
+  (close [_this]
+    (writes/stop-writer! writes-handle)))
+
+(defn- calculate-settings [settings]
+  (let [default-settings {:max-update-size 5000}]
+    (merge default-settings settings)))
+
+(defn create
+  "Creates a new model with the given backend database and time source"
+  ([repo] (create repo {}))
+  ([repo {:keys [clock graph-manager settings]}]
+   (let [clock (or clock time/system-clock)
+         graph-manager (or graph-manager (graphs/create-manager repo #{} clock))
+         global-writes-lock (write-scheduler/create-writes-lock)
+         operations {:revert-draftset-graph-changes revert-draftset-graph-changes-op
+                     :claim-draftset                claim-draftset-op
+                     :create-draftset               create-draftset-op
+                     :delete-draftset               delete-draftset-op
+                     :list-draftsets                list-draftsets-op
+                     :draftset-options              draftset-options-op
+                     :publish-draftset              publish-draftset-op
+                     :draftset-query-endpoint       draftset-query-endpoint-op
+                     :set-draftset-metadata         set-draftset-metadata-op
+                     :show-draftset                 show-draftset-op
+                     :submit-draftset               submit-draftset-op
+
+                     :live-query-endpoint           live-query-endpoint-op
+
+                     :append-draftset-data          append-draftset-data-op
+                     :copy-live-graph-into-draftset copy-live-graph-into-draftset-op
+                     :delete-draftset-data          delete-draftset-data-op
+                     :delete-draftset-graph         delete-draftset-graph-op
+                     :get-draftset-data             get-draftset-data-op
+
+                     :submit-update-request         submit-update-request-op}
+         writes-handle (writes/start-writer! global-writes-lock)
+         settings (calculate-settings settings)]
+     (->ModelDrafter repo clock graph-manager global-writes-lock writes-handle operations settings))))
+
+(defn make-sync
+  "Returns a model implementation which converts all asynchronous operations (i.e. those which return
+   job responses) into synchronous operations which wait up to a configurable timeout for the inner
+   job to complete."
+  ([drafter] (make-sync drafter 10))
+  ([drafter timeout-seconds]
+   (letfn [(make-sync [op]
+             (fn [& args]
+               (let [job (apply op args)
+                     timeout-ms (* 1000 timeout-seconds)
+                     result (deref job timeout-ms ::timeout)]
+                 (cond
+                   (= ::timeout result)
+                   (throw (ex-info "Timed out waiting for job" {}))
+
+                   (= :ok (:type result))
+                   result
+
+                   :else
+                   (throw (ex-info "Job failed" {:result result}))))))]
+     (let [async-ops #{:delete-draftset :publish-draftset :append-draftset-data
+                       :copy-live-graph-into-draftset :delete-draftset-data}]
+       (update drafter :operations (fn [operations]
+                                     (reduce (fn [acc async-op]
+                                               (update acc async-op make-sync))
+                                             operations
+                                             async-ops)))))))
+
+(defn- get-op [drafter op-key]
+  (get-in drafter [:operations op-key]))
+
+(defn revert-graph-changes
+  "Reverts changes to a graph within a draftset"
+  [drafter user draftset-ref graph]
+  ((get-op drafter :revert-draftset-graph-changes) drafter user draftset-ref graph))
+
+(defn claim-draftset
+  "Claims an available draftset for a user"
+  [drafter user draftset-ref]
+  ((get-op drafter :claim-draftset) drafter user draftset-ref))
+
+(defn create-draftset
+  "Creates a new draftset owned by the given user"
+  ([drafter user] (create-draftset drafter user {}))
+  ([drafter user opts]
+   ((get-op drafter :create-draftset) drafter user opts)))
+
+(defn delete-draftset
+  "Deletes a draftset owned by a user"
+  ([drafter user draftset-ref] (delete-draftset drafter user draftset-ref {}))
+  ([drafter user draftset-ref opts]
+   ((get-op drafter :delete-draftset) drafter user draftset-ref opts)))
+
+(defn list-draftsets
+  "Lists the draftsets visible to a user"
+  ([drafter user] (list-draftsets drafter user {}))
+  ([drafter user opts]
+   ((get-op drafter :list-draftsets) drafter user opts)))
+
+(defn draftset-options
+  "Returns the operations available to a user on a draftset"
+  [drafter user draftset-ref]
+  ((get-op drafter :draftset-options) drafter user draftset-ref))
+
+(defn publish-draftset
+  "Publishes a draftset owned by user"
+  ([drafter user draftset-ref] (publish-draftset drafter user draftset-ref {}))
+  ([drafter user draftset-ref opts]
+   ((get-op drafter :publish-draftset) drafter user draftset-ref opts)))
+
+(defn get-draftset-query-endpoint
+  "Returns a repository for querying a draftset"
+  ([drafter user draftset-ref] (get-draftset-query-endpoint drafter user draftset-ref {}))
+  ([drafter user draftset-ref opts]
+   ((get-op drafter :draftset-query-endpoint) drafter user draftset-ref opts)))
+
+(defn get-live-query-endpoint
+  "Returns a repository for querying the live data"
+  [drafter]
+  ((get-op drafter :live-query-endpoint) drafter))
+
+(defn get-raw-repo
+  "Returns the inner unrestricted repository for the entire database"
+  [drafter]
+  (:backend drafter))
+
+(defn set-draftset-metadata [drafter user draftset-ref metadata]
+  ((get-op drafter :set-draftset-metadata) drafter user draftset-ref metadata))
+
+(defn show-draftset
+  "Returns the current state of a draftset owned by user"
+  ([drafter user draftset-ref] (show-draftset drafter user draftset-ref {}))
+  ([drafter user draftset-ref opts]
+   ((get-op drafter :show-draftset) drafter user draftset-ref opts)))
+
+(defn- submit-draftset [drafter user draftset-ref opts]
+  ((get-op drafter :submit-draftset) drafter user draftset-ref opts))
+
+(defn submit-draftset-to-user
+  "Submits a draftset owned by user to a specific user"
+  [drafter user draftset-ref target-user]
+  (submit-draftset drafter user draftset-ref {:user target-user}))
+
+(defn submit-draftset-to-role
+  "Submits a draftset owned by user to a role"
+  [drafter user draftset-ref target-role]
+  (submit-draftset drafter user draftset-ref {:role target-role}))
+
+(defn append-data
+  "Appends data from an RDF source to a draftset"
+  ([drafter user draftset-ref source]
+   (append-data drafter user draftset-ref source {}))
+  ([drafter user draftset-ref source opts]
+   ((get-op drafter :append-draftset-data) drafter user draftset-ref source opts)))
+
+(defn copy-live-graph
+  "Copies a live graph into a draftset"
+  ([drafter user draftset-ref graph] (copy-live-graph drafter user draftset-ref graph {}))
+  ([drafter user draftset-ref graph opts]
+   ((get-op drafter :copy-live-graph-into-draftset) drafter user draftset-ref graph opts)))
+
+(defn delete-data
+  "Deletes data from an RDF source from a draftset"
+  ([drafter user draftset-ref source] (delete-data drafter user draftset-ref source {}))
+  ([drafter user draftset-ref source opts]
+   ((get-op drafter :delete-draftset-data) drafter user draftset-ref source opts)))
+
+(defn delete-graph
+  "Deletes a graph within a draftset"
+  ([drafter user draftset-ref graph] (delete-graph drafter user draftset-ref graph {}))
+  ([drafter user draftset-ref graph opts]
+   ((get-op drafter :delete-draftset-graph) drafter user draftset-ref graph opts)))
+
+(defn get-data
+  "Returns RDF data within a draftset. If the :graph option is specified only the data from
+   the specified graph is returned otherwise all quads will be returned."
+  ([drafter user draftset-ref] (get-data drafter user draftset-ref {}))
+  ([drafter user draftset-ref opts]
+   ((get-op drafter :get-draftset-data) drafter user draftset-ref opts)))
+
+(defn submit-update-request
+  "Submits a SPARQL UPDATE query within a draftset"
+  [drafter user draftset-ref sparql-update-query]
+  ((get-op drafter :submit-update-request) drafter user draftset-ref sparql-update-query))
+
+(t/deftest operations-test
+  (tc/with-system
+    [:drafter/backend :drafter.fixture-data/loader]
+    [system "drafter/feature/empty-db-system.edn"]
+    (let [repo (:drafter/backend system)
+          t1 (OffsetDateTime/of 2020 12 30 14 52 13 0 ZoneOffset/UTC)]
+      (with-open [drafter (make-sync (create repo {:clock t1}))]
+        (let [ds-id (create-draftset drafter test-publisher {:id "test" :display-name "Count Draftula" :description "My amazing draftset"})
+              _ds (show-draftset drafter test-publisher ds-id {})
+              _dsu (show-draftset drafter test-publisher ds-id {:union-with-live? true})
+              _ds-list (list-draftsets drafter test-publisher {})]
+
+          ;;lifecycle
+          (submit-draftset-to-role drafter test-publisher ds-id :editor)
+          (claim-draftset drafter test-editor ds-id)
+          (submit-draftset-to-user drafter test-editor ds-id test-publisher)
+          (claim-draftset drafter test-publisher ds-id)
+          (let [_ds (show-draftset drafter test-publisher ds-id {})])
+
+          ;;data
+          (let [quads [(pr/->Quad (URI. "http://s1") (URI. "http://p1") "o1" (URI. "http://g1"))
+                       (pr/->Quad (URI. "http://s1") (URI. "http://p2") "o2" (URI. "http://g1"))
+                       (pr/->Quad (URI. "http://s1") (URI. "http://p3") "o3" (URI. "http://g1"))
+                       (pr/->Quad (URI. "http://s2") (URI. "http://p1") "o4" (URI. "http://g2"))]
+                to-delete [(pr/->Quad (URI. "http://s1") (URI. "http://p2") "o2" (URI. "http://g1"))]]
+            (append-data drafter test-publisher ds-id (ses/->CollectionStatementSource quads))
+            (delete-graph drafter test-publisher ds-id (URI. "http://g2") {})
+            (t/is (thrown? ExceptionInfo (delete-graph drafter test-publisher ds-id (URI. "http://missing") {:silent false})))
+            (delete-data drafter test-publisher ds-id (ses/->CollectionStatementSource to-delete) {})
+
+            (let [quads (get-data drafter test-publisher ds-id {})
+                  graph-triples (get-data drafter test-publisher ds-id {:graph (URI. "http://g1")})
+                  query-endpoint (get-draftset-query-endpoint drafter test-publisher ds-id {:union-with-live? false})]
+              (t/is (= #{(pr/->Quad (URI. "http://s1") (URI. "http://p1") "o1" (URI. "http://g1"))
+                         (pr/->Quad (URI. "http://s1") (URI. "http://p3") "o3" (URI. "http://g1"))} (set quads)))
+              (t/is (= #{(pr/->Triple (URI. "http://s1") (URI. "http://p1") "o1")
+                         (pr/->Triple (URI. "http://s1") (URI. "http://p3") "o3")}
+                       (set graph-triples)))
+
+              (with-open [conn (repo/->connection query-endpoint)]
+                (let [q "SELECT ?o WHERE { GRAPH <http://g1> { <http://s1> <http://p3> ?o } }"
+                      bindings (vec (repo/query conn q))]
+                  (t/is (= [{:o "o3"}] bindings)))))
+
+            (let [live-endpoint (get-live-query-endpoint drafter)
+                  triples (with-open [conn (repo/->connection live-endpoint)]
+                            (set (repo/query conn "CONSTRUCT { ?s ?p ?o } WHERE { ?s ?p ?o }")))]
+              (t/is (empty? triples) "Live should be empty until publish"))
+
+            (publish-draftset drafter test-publisher ds-id)
+
+            (let [live-endpoint (get-live-query-endpoint drafter)
+                  triples (with-open [conn (repo/->connection live-endpoint)]
+                            (set (repo/query conn "CONSTRUCT { ?s ?p ?o } WHERE { ?s ?p ?o }")))]
+              (t/is (= #{(pr/->Triple (URI. "http://s1") (URI. "http://p1") "o1")
+                         (pr/->Triple (URI. "http://s1") (URI. "http://p3") "o3")} triples) "Live should contain published draft data"))
+
+            (let [ds2-id (create-draftset drafter test-editor {:id "second" :display-name "Second test draftset"})
+                  query-endpoint (get-draftset-query-endpoint drafter test-editor ds2-id {:union-with-live? true})
+                  bindings (with-open [conn (repo/->connection query-endpoint)]
+                             (vec (repo/query conn "SELECT ?p WHERE { GRAPH <http://g1> { <http://s1> ?p \"o1\" } }")))
+                  to-append [(pr/->Quad (URI. "http://s3") (URI. "http://p4") "o5" (URI. "http://g1"))]]
+              (t/is (= [{:p (URI. "http://p1")}] bindings))
+
+              (append-data drafter test-editor ds2-id (ses/->CollectionStatementSource to-append))
+              (revert-graph-changes drafter test-editor ds2-id (URI. "http://g1"))
+              (delete-draftset drafter test-editor ds2-id))))))))

--- a/drafter/test/drafter/rdf/draftset_management/jobs_test.clj
+++ b/drafter/test/drafter/rdf/draftset_management/jobs_test.clj
@@ -8,7 +8,8 @@
             [grafter-2.rdf.protocols :refer [->Triple]]
             [drafter.backend.draftset.operations :as ops]
             [drafter.backend.draftset.draft-management :as mgmt]
-            [drafter.time :as time])
+            [drafter.time :as time]
+            [drafter.manager :as manager])
   (:import java.net.URI))
 
 (t/use-fixtures :each tc/with-spec-instrumentation)
@@ -19,24 +20,19 @@
   (let [results (sparql/eager-query backend (tc/select-all-in-graph graph-uri))]
     (map (fn [{:keys [s p o]}] (->Triple s p o)) results)))
 
-(defn- job-resources [system]
-  {:backend (:drafter/backend system)
-   :global-writes-lock (:drafter/global-writes-lock system)
-   :graph-manager (:drafter.backend.draftset.graphs/manager system)})
+(defn- create-manager [system clock]
+  (let [repo (:drafter/backend system)
+        writes-lock (:drafter/global-writes-lock system)]
+    (manager/create-manager repo {:clock clock :global-writes-lock writes-lock})))
 
 (t/deftest copy-live-graph-into-draftset-test
   (tc/with-system
-    [{:keys [:drafter/backend :drafter/global-writes-lock] :as system} "drafter/rdf/draftset-management/jobs.edn"]
-    (let [resources (job-resources system)
+    [{:keys [:drafter/backend] :as system} "drafter/rdf/draftset-management/jobs.edn"]
+    (let [resources (create-manager system time/system-clock)
           draftset-id (dsops/create-draftset! backend test-editor)
           live-triples (tc/test-triples (URI. "http://test-subject"))
           live-graph-uri (tc/make-graph-live! backend (URI. "http://live") live-triples)
-          copy-job (append-graph/copy-live-graph-into-draftset-job
-                     resources
-                     dummy
-                     {:draftset-id draftset-id
-                      :graph       live-graph-uri}
-                     time/system-clock)]
+          copy-job (append-graph/copy-live-graph-into-draftset-job resources dummy draftset-id live-graph-uri nil)]
       (tc/exec-and-await-job-success copy-job)
       (let [draft-graph (dsops/find-draftset-draft-graph backend draftset-id live-graph-uri)
             draft-triples (get-graph-triples backend draft-graph)]
@@ -45,30 +41,24 @@
 (t/deftest copy-live-graph-into-existing-draft-graph-in-draftset-test
   (tc/with-system
     [{:keys [:drafter/backend] :as system} "drafter/rdf/draftset-management/jobs.edn"]
-    (let [resources (job-resources system)
+    (let [resources (create-manager system time/system-clock)
           draftset-id (dsops/create-draftset! backend test-editor)
           live-triples (tc/test-triples (URI. "http://test-subject"))
           live-graph-uri (tc/make-graph-live! backend (URI. "http://live") live-triples)
           initial-draft-triples (tc/test-triples (URI. "http://temp-subject"))
           draft-graph-uri (tc/import-data-to-draft! backend live-graph-uri initial-draft-triples draftset-id)
-          copy-job (append-graph/copy-live-graph-into-draftset-job
-                     resources
-                     dummy
-                     {:draftset-id draftset-id
-                      :graph       live-graph-uri}
-                     time/system-clock)]
+          copy-job (append-graph/copy-live-graph-into-draftset-job resources dummy draftset-id live-graph-uri nil)]
       (tc/exec-and-await-job-success copy-job)
       (let [draft-triples (get-graph-triples backend draft-graph-uri)]
         (t/is (= (set live-triples) (set draft-triples)))))))
 
 (t/deftest copy-live-graph-into-draftset-job-should-not-copy-protected-graphs
   (tc/with-system
-    [{:keys [:drafter/backend :drafter/global-writes-lock] :as system} "drafter/rdf/draftset-management/jobs.edn"]
-    (let [{:keys [backend] :as resources} (job-resources system)
+    [{:keys [:drafter/backend] :as system} "drafter/rdf/draftset-management/jobs.edn"]
+    (let [{:keys [backend] :as resources} (create-manager system time/system-clock)
           draftset-id (dsops/create-draftset! backend test-editor)
           protected-graph mgmt/drafter-state-graph
-          params {:draftset-id draftset-id :graph protected-graph}
-          job (append-graph/copy-live-graph-into-draftset-job resources dummy params time/system-clock)
+          job (append-graph/copy-live-graph-into-draftset-job resources dummy draftset-id protected-graph nil)
           result (tc/exec-and-await-job job)
           draft-graph (ops/find-draftset-draft-graph backend draftset-id protected-graph)]
       (t/is (= :error (:type result)))

--- a/drafter/test/drafter/test_common.clj
+++ b/drafter/test/drafter/test_common.clj
@@ -307,7 +307,7 @@
    (let [start (System/currentTimeMillis)]
      (loop [guid (job-path->job-id path)]
        (if-let [job (async/complete-job guid)]
-         @(:value-p job)
+         @job
          (if (> (System/currentTimeMillis) (+ start (or timeout default-timeout) ))
            (throw (RuntimeException. "Timed out awaiting test value"))
            (do
@@ -513,9 +513,9 @@
   "Executes a job and waits the specified timeout period for it to complete.
    Returns the result of the job if it completed within the timeout period."
   ([job] (exec-and-await-job job 10))
-  ([{:keys [value-p] :as job} timeout-seconds]
+  ([job timeout-seconds]
    (scheduler/queue-job! job)
-   (let [result (deref value-p (* 1000 timeout-seconds) ::timeout)]
+   (let [result (deref job (* 1000 timeout-seconds) ::timeout)]
      (when (= ::timeout result)
        (throw (ex-info (format "Job failed to complete after %d seconds" timeout-seconds)
                        {:job job})))

--- a/drafter/test/resources/backend/draftset-test.edn
+++ b/drafter/test/resources/backend/draftset-test.edn
@@ -1,7 +1,0 @@
-#merge [{:drafter.backend.draftset/endpoint {:repo #ig/ref :drafter.stasher/repo }}
-        #include "../repo.edn"
-        #include "../user-repo.edn"
-        #include "../log-system.edn"
-        #include "../web.edn"
-        {:drafter.fixture-data/loader {:repo #ig/ref :drafter.stasher/repo
-                                       :fixtures [#resource "drafter/stasher-test/drafter-state-1.trig"]}}]

--- a/drafter/test/resources/drafter/feature/empty-db-system-manual-clock.edn
+++ b/drafter/test/resources/drafter/feature/empty-db-system-manual-clock.edn
@@ -1,10 +1,8 @@
 #merge
 [#include "empty-db-system.edn"
  {:drafter.test-common/manual-clock {}
-  :drafter.feature.draftset.update/handler
+  :drafter/manager
   {:drafter/backend #ig/ref :drafter/backend
-   :drafter.backend.draftset.graphs/manager #ig/ref :drafter.backend.draftset.graphs/manager
+   :drafter/global-writes-lock #ig/ref :drafter/global-writes-lock
    :drafter.time/clock #ig/ref :drafter.test-common/manual-clock
-   :wrap-as-draftset-owner #ig/ref :drafter.feature.middleware/wrap-as-draftset-owner
-   :max-update-size 50
-   :drafter/global-writes-lock #ig/ref :drafter/global-writes-lock}}]
+   :drafter.backend.draftset.graphs/manager #ig/ref :drafter.backend.draftset.graphs/manager}}]

--- a/drafter/test/resources/drafter/routes/sparql-test/repo.edn
+++ b/drafter/test/resources/drafter/routes/sparql-test/repo.edn
@@ -19,7 +19,6 @@
                         :sparql-update-endpoint #ig/ref :drafter.common.config/sparql-update-endpoint
                         }
 
-
  ;;;; A repo specifically for the live query endpoint
  :drafter.backend.live/endpoint {:repo #ig/ref :drafter.stasher/repo}
 
@@ -29,7 +28,10 @@
  :drafter.backend.draftset.graphs/manager {:repo #ig/ref :drafter.stasher/repo
                                            :drafter.time/clock #ig/ref :drafter.time/system-clock}
 
- :drafter.backend.draftset/endpoint {:repo #ig/ref :drafter.stasher/repo}
+ :drafter/manager {:drafter/backend #ig/ref :drafter/backend
+                   :drafter/global-writes-lock #ig/ref :drafter/global-writes-lock
+                   :drafter.time/clock #ig/ref :drafter.time/system-clock
+                   :drafter.backend.draftset.graphs/manager #ig/ref :drafter.backend.draftset.graphs/manager}
 
  :drafter/write-scheduler {:port #long #or [#port #env DRAFTER_HTTP_PORT 3003]
                            :drafter/global-writes-lock #ig/ref :drafter/global-writes-lock}

--- a/drafter/test/resources/repo.edn
+++ b/drafter/test/resources/repo.edn
@@ -28,7 +28,10 @@
  :drafter.backend.draftset.graphs/manager {:repo #ig/ref :drafter.stasher/repo
                                            :drafter.time/clock #ig/ref :drafter.time/system-clock}
 
- :drafter.backend.draftset/endpoint {:repo #ig/ref :drafter.stasher/repo}
+ :drafter/manager {:drafter/backend #ig/ref :drafter/backend
+                   :drafter/global-writes-lock #ig/ref :drafter/global-writes-lock
+                   :drafter.time/clock #ig/ref :drafter.time/system-clock
+                   :drafter.backend.draftset.graphs/manager #ig/ref :drafter.backend.draftset.graphs/manager}
 
  :drafter/write-scheduler {:port #long #or [#port #env DRAFTER_HTTP_PORT 3003]
                            :drafter/global-writes-lock #ig/ref :drafter/global-writes-lock}

--- a/drafter/test/resources/web.edn
+++ b/drafter/test/resources/web.edn
@@ -30,10 +30,6 @@
  ;; [:drafter.timeouts/timeout-query :drafter/draftset-timeout] {:endpoint-timeout 30
  ;;                                                              :jws-signing-key "foo"}
 
- ;; :drafter.routes.sparql/live-sparql-query-route {:repo #ig/ref :drafter.backend.draftset/endpoint
- ;;                                                 :endpoint-timeout-fn #ig/ref [:drafter.timeouts/timeout-query :drafter/live-timeout]}
-
-
  ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
  [:drafter.timeouts/timeout-query :drafter/live-timeout] {:endpoint-timeout #timeout #env DRAFTER_TIMEOUT_QUERY_ENDPOINT_LIVE
@@ -54,17 +50,13 @@
                                                        :wrap-auth #ig/ref :drafter.middleware/wrap-auth}
 
 
- :drafter.feature.draftset.create/handler {:drafter/backend #ig/ref :drafter/backend
-                                           :drafter/global-writes-lock #ig/ref :drafter/global-writes-lock
-                                           :drafter.time/clock #ig/ref :drafter.time/system-clock
+ :drafter.feature.draftset.create/handler {:drafter/manager #ig/ref :drafter/manager
                                            :wrap-auth #ig/ref :drafter.middleware/wrap-auth}
 
  :drafter.feature.middleware/wrap-as-draftset-owner {:drafter/backend #ig/ref :drafter/backend
                                                        :wrap-auth #ig/ref :drafter.middleware/wrap-auth}
 
  :drafter.feature.draftset.delete/handler {:drafter/backend #ig/ref :drafter/backend
-                                           :drafter/global-writes-lock #ig/ref :drafter/global-writes-lock
-                                           :drafter.time/clock #ig/ref :drafter.time/system-clock
                                            :wrap-as-draftset-owner #ig/ref :drafter.feature.middleware/wrap-as-draftset-owner}
 
  :drafter.feature.draftset.options/handler {:drafter/backend #ig/ref :drafter/backend
@@ -74,69 +66,50 @@
                                               :wrap-as-draftset-owner #ig/ref :drafter.feature.middleware/wrap-as-draftset-owner
                                               :timeout-fn #ig/ref [:drafter.timeouts/timeout-query :drafter/draftset-timeout]}
 
- :drafter.feature.draftset-data.delete/delete-data-handler {:drafter/backend #ig/ref :drafter/backend
-                                                            :drafter/global-writes-lock #ig/ref :drafter/global-writes-lock
-                                                            :drafter.backend.draftset.graphs/manager #ig/ref :drafter.backend.draftset.graphs/manager
-                                                            :drafter.time/clock #ig/ref :drafter.time/system-clock
+ :drafter.feature.draftset-data.delete/delete-data-handler {:drafter/manager #ig/ref :drafter/manager
                                                             :wrap-as-draftset-owner #ig/ref :drafter.feature.middleware/wrap-as-draftset-owner}
 
  :drafter.feature.draftset-data.delete-by-graph/sync-job-handler
- {:backend #ig/ref :drafter/backend
-  :drafter.backend.draftset.graphs/manager #ig/ref :drafter.backend.draftset.graphs/manager
-  :global-writes-lock #ig/ref :drafter/global-writes-lock}
+ {:drafter/manager #ig/ref :drafter/manager}
 
  :drafter.feature.draftset-data.delete-by-graph/async-job-handler
- {:backend #ig/ref :drafter/backend
-  :drafter.backend.draftset.graphs/manager #ig/ref :drafter.backend.draftset.graphs/manager}
+ {:drafter/manager #ig/ref :drafter/manager}
 
  :drafter.feature.draftset-data.delete-by-graph/remove-graph-handler
- {:drafter/backend #ig/ref :drafter/backend
+ {:drafter/manager #ig/ref :drafter/manager
   :wrap-as-draftset-owner #ig/ref :drafter.feature.middleware/wrap-as-draftset-owner
   :sync-job-handler #ig/ref :drafter.feature.draftset-data.delete-by-graph/sync-job-handler
   :async-job-handler #ig/ref :drafter.feature.draftset-data.delete-by-graph/async-job-handler}
 
- :drafter.feature.draftset.changes/delete-changes-handler {:drafter/backend #ig/ref :drafter/backend
-                                                           :drafter/global-writes-lock #ig/ref :drafter/global-writes-lock
+ :drafter.feature.draftset.changes/delete-changes-handler {:drafter/manager #ig/ref :drafter/manager
                                                            :wrap-as-draftset-owner #ig/ref :drafter.feature.middleware/wrap-as-draftset-owner}
 
- :drafter.feature.draftset-data.append/data-handler {:drafter/backend #ig/ref :drafter/backend
-                                                     :drafter/global-writes-lock #ig/ref :drafter/global-writes-lock
-                                                     :drafter.backend.draftset.graphs/manager #ig/ref :drafter.backend.draftset.graphs/manager
-                                                     :drafter.time/clock #ig/ref :drafter.time/system-clock
+ :drafter.feature.draftset-data.append/data-handler {:drafter/manager #ig/ref :drafter/manager
                                                      :wrap-as-draftset-owner #ig/ref :drafter.feature.middleware/wrap-as-draftset-owner}
 
- :drafter.feature.draftset-data.append-by-graph/handler {:drafter/backend #ig/ref :drafter/backend
-                                                         :drafter/global-writes-lock #ig/ref :drafter/global-writes-lock
-                                                         :drafter.backend.draftset.graphs/manager #ig/ref :drafter.backend.draftset.graphs/manager
-                                                         :drafter.time/clock #ig/ref :drafter.time/system-clock
+ :drafter.feature.draftset-data.append-by-graph/handler {:drafter/manager #ig/ref :drafter/manager
                                                          :wrap-as-draftset-owner #ig/ref :drafter.feature.middleware/wrap-as-draftset-owner}
 
  :drafter.feature.draftset.query/handler {:drafter/backend #ig/ref :drafter/backend
                                           :wrap-as-draftset-owner #ig/ref :drafter.feature.middleware/wrap-as-draftset-owner
                                           :timeout-fn #ig/ref [:drafter.timeouts/timeout-query :drafter/draftset-timeout]}
 
- :drafter.feature.draftset.update/handler {:drafter/backend #ig/ref :drafter/backend
-                                           :drafter.backend.draftset.graphs/manager #ig/ref :drafter.backend.draftset.graphs/manager
-                                           :drafter.time/clock #ig/ref :drafter.time/system-clock
+ :drafter.feature.draftset.update/handler {:drafter/manager #ig/ref :drafter/manager
                                            :wrap-as-draftset-owner #ig/ref :drafter.feature.middleware/wrap-as-draftset-owner
                                            :max-update-size 50}
 
- :drafter.feature.draftset.publish/handler {:drafter/backend #ig/ref :drafter/backend
-                                            :drafter.time/clock #ig/ref :drafter.time/system-clock
+ :drafter.feature.draftset.publish/handler {:drafter/manager #ig/ref :drafter/manager
                                             :wrap-as-draftset-owner #ig/ref :drafter.feature.middleware/wrap-as-draftset-owner}
 
- :drafter.feature.draftset.set-metadata/handler {:drafter/backend #ig/ref :drafter/backend
-                                                 :drafter/global-writes-lock #ig/ref :drafter/global-writes-lock
+ :drafter.feature.draftset.set-metadata/handler {:drafter/manager #ig/ref :drafter/manager
                                                  :wrap-as-draftset-owner #ig/ref :drafter.feature.middleware/wrap-as-draftset-owner}
 
- :drafter.feature.draftset.submit/handler {:drafter/backend #ig/ref :drafter/backend
-                                           :drafter/global-writes-lock #ig/ref :drafter/global-writes-lock
+ :drafter.feature.draftset.submit/handler {:drafter/manager #ig/ref :drafter/manager
                                            :drafter.user/repo #ig/ref :drafter.user/repo
                                            :wrap-as-draftset-owner #ig/ref :drafter.feature.middleware/wrap-as-draftset-owner}
 
  :drafter.feature.draftset.claim/handler {:wrap-auth #ig/ref :drafter.middleware/wrap-auth
-                                          :drafter/global-writes-lock #ig/ref :drafter/global-writes-lock
-                                          :drafter/backend #ig/ref :drafter/backend}
+                                          :drafter/manager #ig/ref :drafter/manager}
 
  :drafter.feature.users.list/get-users-handler {:wrap-auth #ig/ref :drafter.middleware/wrap-auth
                                                   :drafter.user/repo #ig/ref :drafter.user/repo}


### PR DESCRIPTION
Issue #500 - Define an interface for each drafter operation and
create a test model Drafter implementation which uses the inner
implementation as much as possible. Separate the implementation
of each operation from the details of the HTTP API.

Add sync wrapper implementation which waits a configurable timeout
for each async operation.

Add drafter.manager component which contains the components required
by most operations - the backend repository, graph manager, global
writes lock and clock. Refactor each handler to depend on this
instead of each inner component separately.

Add constructor function for write locks and call it from the
integrant initialiser.

Refactor the delete-by-graph handler to separate the graph deletion
logic from the HTTP processing. The handler now calls a delete-graph
function which does the delete in a synchronous job and raises
an exception if the job fails or request is invalid.

Refactor update handler to allow UPDATE query strings to be parsed
directly.

Add specs for the write-scheduler, draftset.graphs and new
drafter.manager namespaces

Implement IDeref and IBlockingDeref on the Job record