### PR TITLE
Make drafter-client polling time configurable

### DIFF
--- a/drafter-client/src/drafter_client/client/protocols.clj
+++ b/drafter-client/src/drafter_client/client/protocols.clj
@@ -12,6 +12,7 @@
       :martian martian
       :auth0 auth0
       :auth-provider auth-provider
+      :opts opts
       (or (get opts k)
           (.valAt martian k default)))))
 


### PR DESCRIPTION
The very conservative 500ms poll time is a sensible default for the admin front end in muttnik etc, but is far too slow for programatic use cases where you may be loading lots of small fixtures like we do in muttnik in dev/test. 


Used in https://github.com/Swirrl/muttnik/pull/1051
