### PR TITLE
tolerate missing versions

### DIFF
--- a/drafter-client/src/drafter_client/client/draftset.clj
+++ b/drafter-client/src/drafter_client/client/draftset.clj
@@ -43,7 +43,7 @@
       (update :id uuid)
       (update :created-at date-time)
       (update :updated-at date-time)
-      (update :version #(URI. %))
+      (update :version #(when % (URI. %)))
       (assoc :name (:display-name ds))
       (dissoc :display-name)
       (map->Draftset)))

--- a/drafter-client/src/drafter_client/client/endpoint.clj
+++ b/drafter-client/src/drafter_client/client/endpoint.clj
@@ -34,7 +34,7 @@
   (-> json
       (update :created-at util/date-time)
       (update :updated-at util/date-time)
-      (update :version #(URI. %))
+      (update :version #(when % (URI. %)))
       (map->Endpoint)))
 
 


### PR DESCRIPTION
This will allow the current client version to talk to older versions of drafter that don't have version information. Currently you get a null exception.

_NOTE:_ this PR is necessary for the client to work with drafter releases [prior to and including 2.4.3](https://github.com/Swirrl/drafter/releases/tag/2.4.3).