### PR TITLE
Prevent Log4Shell vulnerability CVE-2021-44228

### DIFF
--- a/drafter-client/deps.edn
+++ b/drafter-client/deps.edn
@@ -30,9 +30,9 @@
                               environ/environ {:mvn/version "1.0.3"}
                               integrant/repl {:mvn/version "0.3.1"}
 
-                              org.apache.logging.log4j/log4j-api {:mvn/version "2.11.1"} ; Import log4j2 as the logging backend
-                              org.apache.logging.log4j/log4j-core {:mvn/version "2.11.1"} ; Import log4j2 as the logging backend
-                              org.apache.logging.log4j/log4j-slf4j-impl {:mvn/version "2.11.1"} ; Redirect all SLF4J logs over the log4j2 backend
+                              org.apache.logging.log4j/log4j-api {:mvn/version "2.15.0"} ; Import log4j2 as the logging backend
+                              org.apache.logging.log4j/log4j-core {:mvn/version "2.15.0"} ; Import log4j2 as the logging backend
+                              org.apache.logging.log4j/log4j-slf4j-impl {:mvn/version "2.15.0"} ; Redirect all SLF4J logs over the log4j2 backend
 
 
                               }}

--- a/drafter/deps.edn
+++ b/drafter/deps.edn
@@ -66,9 +66,9 @@
         org.mindrot/jbcrypt {:mvn/version "0.4"}
 
         org.clojure/tools.logging {:mvn/version "0.5.0"}
-        org.apache.logging.log4j/log4j-api {:mvn/version "2.11.1"} ; Import log4j2 as the logging backend
-        org.apache.logging.log4j/log4j-core {:mvn/version "2.11.1"} ; Import log4j2 as the logging backend
-        org.apache.logging.log4j/log4j-slf4j-impl {:mvn/version "2.11.1"} ; Redirect all SLF4J logs over the log4j2 backend
+        org.apache.logging.log4j/log4j-api {:mvn/version "2.15.0"} ; Import log4j2 as the logging backend
+        org.apache.logging.log4j/log4j-core {:mvn/version "2.15.0"} ; Import log4j2 as the logging backend
+        org.apache.logging.log4j/log4j-slf4j-impl {:mvn/version "2.15.0"} ; Redirect all SLF4J logs over the log4j2 backend
 
         org.slf4j/log4j-over-slf4j {:mvn/version "1.7.25"} ; redirect log4j 1.x logs
         org.slf4j/jcl-over-slf4j {:mvn/version "1.7.25"} ; redirect commons logging


### PR DESCRIPTION
https://www.lunasec.io/docs/blog/log4j-zero-day/
https://www.cve.org/CVERecord?id=CVE-2021-44228