### PR TITLE
Upgrade log4j2 to 2.16.0 to fix CVE 2021-45046

### DIFF
--- a/drafter-client/deps.edn
+++ b/drafter-client/deps.edn
@@ -11,7 +11,7 @@
         martian/martian {:mvn/version "0.1.10"}
         martian-clj-http/martian-clj-http {:mvn/version "0.1.10"}
         org.clojure/clojure {:mvn/version "1.9.0"}
-        org.clojure/tools.logging {:mvn/version "0.4.1"}
+        org.clojure/tools.logging {:mvn/version "1.2.2"}
         ring/ring-core {:mvn/version "1.6.3"}
         clj-time/clj-time {:mvn/version "0.15.1"}
         grafter.db/grafter.db {:mvn/version "0.8.5"}
@@ -30,9 +30,9 @@
                               environ/environ {:mvn/version "1.0.3"}
                               integrant/repl {:mvn/version "0.3.1"}
 
-                              org.apache.logging.log4j/log4j-api {:mvn/version "2.15.0"} ; Import log4j2 as the logging backend
-                              org.apache.logging.log4j/log4j-core {:mvn/version "2.15.0"} ; Import log4j2 as the logging backend
-                              org.apache.logging.log4j/log4j-slf4j-impl {:mvn/version "2.15.0"} ; Redirect all SLF4J logs over the log4j2 backend
+                              org.apache.logging.log4j/log4j-api {:mvn/version "2.16.0"} ; Import log4j2 as the logging backend
+                              org.apache.logging.log4j/log4j-core {:mvn/version "2.16.0"} ; Import log4j2 as the logging backend
+                              org.apache.logging.log4j/log4j-slf4j-impl {:mvn/version "2.16.0"} ; Redirect all SLF4J logs over the log4j2 backend
 
 
                               }}

--- a/drafter/deps.edn
+++ b/drafter/deps.edn
@@ -65,10 +65,10 @@
 
         org.mindrot/jbcrypt {:mvn/version "0.4"}
 
-        org.clojure/tools.logging {:mvn/version "0.5.0"}
-        org.apache.logging.log4j/log4j-api {:mvn/version "2.15.0"} ; Import log4j2 as the logging backend
-        org.apache.logging.log4j/log4j-core {:mvn/version "2.15.0"} ; Import log4j2 as the logging backend
-        org.apache.logging.log4j/log4j-slf4j-impl {:mvn/version "2.15.0"} ; Redirect all SLF4J logs over the log4j2 backend
+        org.clojure/tools.logging {:mvn/version "1.2.2"}
+        org.apache.logging.log4j/log4j-api {:mvn/version "2.16.0"} ; Import log4j2 as the logging backend
+        org.apache.logging.log4j/log4j-core {:mvn/version "2.16.0"} ; Import log4j2 as the logging backend
+        org.apache.logging.log4j/log4j-slf4j-impl {:mvn/version "2.16.0"} ; Redirect all SLF4J logs over the log4j2 backend
 
         org.slf4j/log4j-over-slf4j {:mvn/version "1.7.25"} ; redirect log4j 1.x logs
         org.slf4j/jcl-over-slf4j {:mvn/version "1.7.25"} ; redirect commons logging


### PR DESCRIPTION
Also bumped clojure.tools.logging to latest release.  Not because it
really is a problem; but because it might appear to be a problem.

https://www.lunasec.io/docs/blog/log4j-zero-day-update-on-cve-2021-45046/