### PR TITLE
emergency patch-release: log4shell mitigations for 2.4.8 (dont merge)

### DIFF
--- a/dependencies-mongo-auth.edn
+++ b/dependencies-mongo-auth.edn
@@ -1,3 +1,3 @@
-{"stardog" "6.2.3-1.1" 
+{"stardog" "6.2.3-2.0" 
  "mongodb" "3.2"
  "server-ssl" "1.2021"}

--- a/dependencies.edn
+++ b/dependencies.edn
@@ -1,3 +1,3 @@
 ;; note you should also edit dependencies-mongo-auth (which is used for the tests) or if you want to install mongo (e.g. for pmd3)
-{"stardog" "6.2.3-1.1" ;; NOTE: also update this in dependencies-mongo-auth.edn
+{"stardog" "6.2.3-2.0" ;; NOTE: also update this in dependencies-mongo-auth.edn
  "server-ssl" "1.2021"}

--- a/drafter-client/deps.edn
+++ b/drafter-client/deps.edn
@@ -11,7 +11,7 @@
         martian/martian {:mvn/version "0.1.10"}
         martian-clj-http/martian-clj-http {:mvn/version "0.1.10"}
         org.clojure/clojure {:mvn/version "1.9.0"}
-        org.clojure/tools.logging {:mvn/version "0.4.1"}
+        org.clojure/tools.logging {:mvn/version "1.2.2"}
         ring/ring-core {:mvn/version "1.6.3"}
         clj-time/clj-time {:mvn/version "0.15.1"}
         grafter.db/grafter.db {:mvn/version "0.8.5"}
@@ -30,9 +30,9 @@
                               environ/environ {:mvn/version "1.0.3"}
                               integrant/repl {:mvn/version "0.3.1"}
 
-                              org.apache.logging.log4j/log4j-api {:mvn/version "2.11.1"} ; Import log4j2 as the logging backend
-                              org.apache.logging.log4j/log4j-core {:mvn/version "2.11.1"} ; Import log4j2 as the logging backend
-                              org.apache.logging.log4j/log4j-slf4j-impl {:mvn/version "2.11.1"} ; Redirect all SLF4J logs over the log4j2 backend
+                              org.apache.logging.log4j/log4j-api {:mvn/version "2.16.0"} ; Import log4j2 as the logging backend
+                              org.apache.logging.log4j/log4j-core {:mvn/version "2.16.0"} ; Import log4j2 as the logging backend
+                              org.apache.logging.log4j/log4j-slf4j-impl {:mvn/version "2.16.0"} ; Redirect all SLF4J logs over the log4j2 backend
 
 
                               }}

--- a/drafter/deps.edn
+++ b/drafter/deps.edn
@@ -65,10 +65,10 @@
 
         org.mindrot/jbcrypt {:mvn/version "0.4"}
 
-        org.clojure/tools.logging {:mvn/version "0.5.0"}
-        org.apache.logging.log4j/log4j-api {:mvn/version "2.11.1"} ; Import log4j2 as the logging backend
-        org.apache.logging.log4j/log4j-core {:mvn/version "2.11.1"} ; Import log4j2 as the logging backend
-        org.apache.logging.log4j/log4j-slf4j-impl {:mvn/version "2.11.1"} ; Redirect all SLF4J logs over the log4j2 backend
+        org.clojure/tools.logging {:mvn/version "1.2.2"}
+        org.apache.logging.log4j/log4j-api {:mvn/version "2.16.0"} ; Import log4j2 as the logging backend
+        org.apache.logging.log4j/log4j-core {:mvn/version "2.16.0"} ; Import log4j2 as the logging backend
+        org.apache.logging.log4j/log4j-slf4j-impl {:mvn/version "2.16.0"} ; Redirect all SLF4J logs over the log4j2 backend
 
         org.slf4j/log4j-over-slf4j {:mvn/version "1.7.25"} ; redirect log4j 1.x logs
         org.slf4j/jcl-over-slf4j {:mvn/version "1.7.25"} ; redirect commons logging


### PR DESCRIPTION
[dont merge]

bump log4j2 to 2.16.0, and pick up patched stardog, as log4shell (cve-2021-44228 cve-2021-45046) mitigations

intended to be used temporarily before upgrading to latest drafter (which includes other large changes like the modified date tracking).

Was branched off the 2.4.8 tag.

see this release: [2.4.8-log4shell](https://github.com/Swirrl/drafter/releases/tag/2.4.8-log4shell)