### PR TITLE
Enhance drafter socket connection when remote hosted behind nginx

### DIFF
--- a/package/nginx/drafter-api.template
+++ b/package/nginx/drafter-api.template
@@ -5,7 +5,8 @@ server {
 }
 
 server {
-    listen 443;
+    # listen includes keepalive for the listening socket
+    listen 443 so_keepalive=30m:10:10;
     server_name {{server/drafter-domain}};
     
     include {{install/nginx-dir}}/conf.d/pmd-ssl.shared;
@@ -13,13 +14,18 @@ server {
     location / {
       proxy_pass http://127.0.0.1:{{drafter/http-port}};
       proxy_read_timeout 90s;     # this should be longer than the drafter next-result timeout
+
+      # TCP keepalive for upstream connections
+      # warning: proxy_socket_keepalive only appeared in nginx version 1.15.6
+      #proxy_socket_keepalive      on;
+
       proxy_set_header            Host $host;
       proxy_set_header            X-Real-IP $remote_addr;
       proxy_set_header            X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header            X-Forwarded-Proto $scheme;
    }
 
-   # # Note you can comment out the above and replace with this if you dont want full api access
+   ## Note you can comment out the above and replace with this if you dont want full api access
    #
    # # the live endpoint
    # location /v1/sparql/live {


### PR DESCRIPTION
This simple patch attempts to address muttnik issue https://github.com/Swirrl/muttnik/issues/1416.

Annecdotally (this is hard to measure properly) I have seen improvements with this revised nginx config on the COGS staging and features server.

When hosted behind nginx, under certain hard to ascertain conditions, connections to drafter can be lost quite regularly. This patch to nginx config attempts to keep the connection alive.

Note: `proxy_socket_keepalive` cannot be used on some of our older nginx installs. The COGS staging server has not been upgraded, but the COGS features server has been upgraded to a recent version of nginx and the results were encouraging.