### PR TITLE
Fix: API redirects downgraded from HTTPS to HTTP in prod

### DIFF
--- a/drafter/src/drafter/handler.clj
+++ b/drafter/src/drafter/handler.clj
@@ -54,7 +54,10 @@
                      (add-routes (denv/env-specific-routes backend))
                      (add-route app-routes))
 
-                 :ring-defaults (assoc-in api-defaults [:params :multipart] true)
+                 :ring-defaults (-> (assoc-in api-defaults [:params :multipart] true)
+                                    ;; Enables wrap-forwarded-scheme middleware. Essential in prod
+                                    ;; env when scheme needs to be passed through from load balancer
+                                    (assoc :proxy true))
                  ;; add custom middleware here
                  :middleware [#(wrap-resource % "swagger-ui")
                               wrap-verbs

--- a/package/nginx/drafter-api.template
+++ b/package/nginx/drafter-api.template
@@ -4,6 +4,17 @@ server {
   rewrite  ^ https://$server_name$request_uri? permanent;
 }
 
+# Sets a $real_scheme variable whose value is the scheme passed by the load
+# balancer in X-Forwarded-Proto (if any), defaulting to $scheme.
+#
+# Similar to how the HttpRealIp module treats X-Forwarded-For.
+# This ensures that we make ring redirects in production work properly.
+# See https://github.com/Swirrl/drafter/pull/561
+map $http_x_forwarded_proto $real_scheme {
+  default $http_x_forwarded_proto;
+  ''      $scheme;
+}
+
 server {
     # listen includes keepalive for the listening socket
     listen 443 so_keepalive=30m:10:10;
@@ -22,7 +33,7 @@ server {
       proxy_set_header            Host $host;
       proxy_set_header            X-Real-IP $remote_addr;
       proxy_set_header            X-Forwarded-For $proxy_add_x_forwarded_for;
-      proxy_set_header            X-Forwarded-Proto $scheme;
+      proxy_set_header            X-Forwarded-Proto $real_scheme;
    }
 
    ## Note you can comment out the above and replace with this if you dont want full api access


### PR DESCRIPTION
Resolves #456

It turns out that all redirects issued by Ring will be downgraded on the server.

This is identical to an issue that we patched in muttnik about 15 months ago.

This is because the Ring request map `:scheme` key is used to generate the redirect uri. In production, the upstream drafter process thinks that the scheme is http rather than https, because the load balancer is where SSL is terminated.

As a result, we need to check for the prescence of an `x-forwarded-proto` header (from the load balancer) within the application code in order to generate the correct redirect_uri.

Ring already has middleware that does this check http://ring-clojure.github.io/ring-ssl/ring.middleware.ssl.html#var-wrap-forwarded-scheme. This Ring middleware is enabled when Ring config has `:proxy` set to `true`.


### In-Situ testing
I replicated this issue on the *features* server. I then made the changes present in this PR on the server and observed that the issue was fixed and that Drafter behaved as intended.