### PR TITLE
Minimal docker compose

### DIFF
--- a/drafter/docker-compose.yml
+++ b/drafter/docker-compose.yml
@@ -1,0 +1,12 @@
+version: "3.9"
+services:
+  stardog:
+    image: "swirrl/stardog:6.2.3"
+    ports:
+      - "5820:5820"
+    environment:
+      - CREATE_DATABASE=drafter-dev-db
+  mongo:
+    image: "mongo:3.2"
+    ports:
+      - "27017:27017"


### PR DESCRIPTION
This PR adds a minimal docker compose for working on drafter (not yet drafter-client) in dev.

## Taking it for a spin

Simply:

`$ cd drafter`
`$ docker-compose up`

Then connect your REPL and:

`(dev)`
`(start-system!)`

and it should work as normal.

NOTE: this does not yet put your dev env (REPL) in a docker.  We could do that too as an extension.  Also it doesn't cover the test env yet.

