### PR TITLE
Upgrade mongodb dep to v4.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ executors:
         auth:
           username: $DOCKERHUB_USERNAME # can specify string literal values
           password: $DOCKERHUB_PASSWORD # or project environment variable reference
-      - image: mongo:3.2
+      - image: mongo:4.4
         auth:
           username: $DOCKERHUB_USERNAME # can specify string literal values
           password: $DOCKERHUB_PASSWORD # or project environment variable reference

--- a/dependencies-mongo-auth.edn
+++ b/dependencies-mongo-auth.edn
@@ -1,3 +1,3 @@
 {"stardog" "6.2.3-2.1"
- "mongodb" "3.2-1.1"
+ "mongodb" "4.4" 
  "server-ssl" "1.2021"}

--- a/drafter/Procfile.example
+++ b/drafter/Procfile.example
@@ -1,2 +1,2 @@
 stardog: trap '../.omni_cache/install/stardog/install/stardog/bin/stardog-admin server stop' EXIT > /dev/null; env STARDOG_HOME=$(pwd)/../.omni_cache/install/stardog/install/stardog-home $(pwd)/../.omni_cache/install/stardog/install/stardog/bin/stardog-admin server start --disable-security --foreground
-mongodb: docker run -p 27017:27017 --rm --name mongodb-dev -v $(pwd)/../.omni_cache/install/mongodb/install/data:/data/db -v $(pwd)/../.omni_cache/install/mongodb/install/dump:/dump mongo:3.2
+mongodb: docker run -p 27017:27017 --rm --name mongodb-dev -v $(pwd)/../.omni_cache/install/mongodb/install/data:/data/db -v $(pwd)/../.omni_cache/install/mongodb/install/dump:/dump mongo:4.4

--- a/drafter/docker-compose.yml
+++ b/drafter/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3.9"
+version: "3.10"
 services:
   stardog:
     image: swirrl/stardog:6.2.3-multi-dbs
@@ -7,6 +7,6 @@ services:
     environment:
       CREATE_DATABASE: drafter-dev-db,drafter-test-db
   mongo:
-    image: mongo:3.2
+    image: mongo:4.4
     ports:
       - "27017:27017"

--- a/package/pmd3-manifest.edn
+++ b/package/pmd3-manifest.edn
@@ -41,5 +41,5 @@
 
               :omni/package-name "drafter-pmd3"
               :omni/dependencies {"stardog" "5.2.0-2.1" ; pmd3 needs stardog 5. 2.1 includes the log4shell patch.
-                                  "mongodb" "3.2-1.1"
+                                  "mongodb" "4.4"
                                   "server-ssl" "1.2021"}}]


### PR DESCRIPTION
Upgrade mongodb deps and refs to v4.4. This is to synchronise with versions used elsewhere in PMD2 / PMD3.