### PR TITLE
Rewrite multiple graph references within draftset statements

### DIFF
--- a/drafter/test/resources/drafter/feature/draftset/publish_test-statements-reference-other-graphs.trig
+++ b/drafter/test/resources/drafter/feature/draftset/publish_test-statements-reference-other-graphs.trig
@@ -1,0 +1,34 @@
+@prefix : <http://example.com/test/publish/statement-references-own-graph#> .
+
+# graph containing only statements that do not reference any graphs
+:g1 {
+  :s1 :p1 :o1 .
+}
+
+# graph containing only references to itself
+:g2 {
+ :g2 :p2 :o2 .
+ :s3 :g2 :o3 .
+ :s4 :p4 :g2 .
+}
+
+# graph contain single references to other graphs
+:g3 {
+  :g2 :p5 :o5 .
+  :s6 :g1 :o6 .
+  :s7 :p7 :g4 .
+}
+
+# graph containing statements with two references to other graphs
+:g4 {
+  :g1 :g3 :o8 .
+  :g3 :p9 :g5 .
+  :s10 :g2 :g2 .
+}
+
+# graph containing statement of three references to graphs
+:g5 {
+  :g1 :g4 :g3 .
+  :g5 :g1 :g5 .
+  :g3 :g2 :g1 .
+}

--- a/drafter/test/resources/drafter/feature/draftset/publish_test-statements-reference-own-graph.trig
+++ b/drafter/test/resources/drafter/feature/draftset/publish_test-statements-reference-own-graph.trig
@@ -1,0 +1,16 @@
+@prefix : <http://example.com/test/publish/statement-references-own-graph#> .
+
+# graph containing statements which reference their own graph
+:g {
+  :s1 :p1 :o1 .
+
+  :g :p2 :o2 .
+  :s3 :g :o3 .
+  :s4 :p4 :g .
+
+  :g :g :o5 .
+  :g :p6 :g .
+  :s7 :g :g .
+
+  :g :g :g .
+}


### PR DESCRIPTION
Issue #607 - Change how draftset query rewriting works to handle
statements which contain multiple graph references to graphs within
the draftset.

The existing query searches for statements which contain a single
reference to a graph within the draft in either the subject,
predicate or object position. This query does not work as expected
for statements which contain two or three components which reference
a graph within the draftset. For these statements, multiple UNION
clauses match the source statement and each component is rewritten
independently, which leads to two or three partially-rewritten
statements within the draft. Running the rewriting query multiple
times causes these extraneous statements to be gradually rewritten
towards their fully-rewritten state, so these may not always be
visible when inserting or deleting data.

Split the current query into three separate queries which rewrite
all subjects, predicates and objects within each statement in the
draftset independently. This prevents the multiple partial match
behaviour of the old query, and also works for statements where
each component references a diffferent graph e.g.

    GRAPH <http://g1> {
        <http://s> <http://g1> <http://g2> .
    }

Add low-level tests for the behaviour of the rewrite-draftset! and
unrewrite-draftset! functions used to rewrite a draft after an
update.

Add higher-level tests which add statements referencing draftset
graphs within a draftset and checks they are published correctly.