### PR TITLE
Log SPARQL queries to a separate log file

### DIFF
--- a/drafter/resources/log4j2.xml
+++ b/drafter/resources/log4j2.xml
@@ -12,10 +12,23 @@
             <PatternLayout>
                 <pattern>%d{ISO8601} %-5p %20.20c{1} %12X{user} %12X{jobId} %12X{reqId} :: %m%n</pattern>
             </PatternLayout>
+            <!-- NOTE: gzip reduces size by ~90% so max log files size is ~1Gb -->
             <Policies>
-                <SizeBasedTriggeringPolicy size="50 MB" />
+                <SizeBasedTriggeringPolicy size="500 MB" />
             </Policies>
-            <DefaultRolloverStrategy max="20"/>
+            <DefaultRolloverStrategy max="10"/>
+        </RollingFile>
+
+        <RollingFile name="sparql" fileName="${log-path}/sparql.log"
+                     filePattern="${log-path}/sparql.%i.log.gz">
+            <PatternLayout>
+                <pattern>%d{ISO8601} %-5p %20.20c{1} %12X{user} %12X{jobId} %12X{reqId} :: %m%n</pattern>
+            </PatternLayout>
+            <!--NOTE: gzip reduces size by ~90% so max log files size is ~2Gb -->
+            <Policies>
+                <SizeBasedTriggeringPolicy size="500 MB" />
+            </Policies>
+            <DefaultRolloverStrategy max="30"/>
         </RollingFile>
 
         <Console name="console" target="SYSTEM_OUT">
@@ -23,6 +36,30 @@
         </Console>
     </Appenders>
     <Loggers>
+        <Logger name="drafter.rdf.sparql-protocol" level="debug" additivity="false">
+            <AppenderRef ref="sparql" />
+        </Logger>
+
+        <Logger name="drafter.rdf.sparql" level="info" additivity="false">
+            <AppenderRef ref="sparql" />
+        </Logger>
+
+        <Logger name="drafter.feature.draftset.update" level="info" additivity="false">
+            <AppenderRef ref="sparql" />
+        </Logger>
+
+        <Logger name="drafter.routes.sparql" level="debug" additivity="false">
+            <AppenderRef ref="sparql" />
+        </Logger>
+
+        <Logger name="drafter.backend.draftset.rewrite-query" level="info" additivity="false">
+            <AppenderRef ref="sparql" />
+        </Logger>
+
+        <Logger name="drafter.stasher" level="info" additivity="false">
+            <AppenderRef ref="sparql" />
+        </Logger>
+
         <Root level="info" additivity="false">
             <appender-ref ref="console" level="warn"/> <!-- only log warnings and worse to REPL -->
             <appender-ref ref="file-log" level="info"/>

--- a/drafter/src/drafter/backend/draftset/rewrite_result.clj
+++ b/drafter/src/drafter/backend/draftset/rewrite_result.clj
@@ -184,6 +184,8 @@
         (.getMaxExecutionTime inner-query))
       (setMaxExecutionTime [this max]
         (.setMaxExecutionTime inner-query max)))
+    '(Object
+       (toString [_this] (.toString inner-query)))
     specs))
 
 (def-rewriting-query-record RewritingBooleanQuery

--- a/drafter/src/drafter/feature/draftset/update.clj
+++ b/drafter/src/drafter/feature/draftset/update.clj
@@ -52,7 +52,8 @@
             [drafter.backend.draftset.graphs :as graphs]
             [drafter.time :as time]
             [drafter.rdf.jena :as jena]
-            [drafter.feature.modified-times :as modified-times])
+            [drafter.feature.modified-times :as modified-times]
+            [clojure.tools.logging :as log])
   (:import java.net.URI
            [org.apache.jena.sparql.modify.request
             QuadDataAcc Target
@@ -402,6 +403,7 @@
                             :max-update-size max-update-size}
 
             update-request' (build-update update-plan update-context)]
+        (log/debugf "About to run rewritten draft UPDATE query: %n%s" update-request')
         (sparql/update! backend update-request')))))
 
 ;; Handler
@@ -479,6 +481,7 @@
             params (parse-update-params request)
             update-query (get-update-query params)
             update-request (parse-update-query manager update-query max-update-size)]
+        (log/infof "Received draft UPDATE query: %n%s" update-query)
         (assoc params :update-request update-request :draftset-id draftset-id))
       (throw (ex-info "Method not supported"
                       {:error :method-not-allowed :method request-method})))))

--- a/drafter/test/resources/log4j2-test.xml
+++ b/drafter/test/resources/log4j2-test.xml
@@ -35,15 +35,27 @@
             <AppenderRef ref="drafter" />
         </Logger>
 
-        <Logger name="drafter.rdf.sparql-protocol" level="debug">
+        <Logger name="drafter.rdf.sparql-protocol" level="debug" additivity="false">
             <AppenderRef ref="sparql" />
         </Logger>
 
-        <Logger name="drafter.routes.sparql" level="debug">
+        <Logger name="drafter.rdf.sparql" level="info" additivity="false">
             <AppenderRef ref="sparql" />
         </Logger>
 
-        <Logger name="drafter.routes.sparql-update" level="debug">
+        <Logger name="drafter.feature.draftset.update" level="info" additivity="false">
+            <AppenderRef ref="sparql" />
+        </Logger>
+
+        <Logger name="drafter.routes.sparql" level="debug" additivity="false">
+            <AppenderRef ref="sparql" />
+        </Logger>
+
+        <Logger name="drafter.backend.draftset.rewrite-query" level="info" additivity="false">
+            <AppenderRef ref="sparql" />
+        </Logger>
+
+        <Logger name="drafter.stasher" level="info" additivity="false">
             <AppenderRef ref="sparql" />
         </Logger>
 


### PR DESCRIPTION
Issue #615 - Log messages within the following namespaces to a
separate sparql.log file:

  * drafter.rdf.sparql-protocol
  * drafter.rdf.sparql
  * drafter.feature.draftset.update
  * drafter.routes.sparql
  * drafter.backend.draftset.rewrite-query
  * drafter.stasher

The sparql.log file is approximately 2-3 times the size of
drafter.log so it is configured to store a larger number of backup
files in the default log configuration.

Add log messages to drafter.feature.draftset.update to log the raw
and re-written UPDATE queries for consistency with the
sparql-protocol namespace used for querying.

Implement Object.toString for re-written SPARQL query records so
these queries are shown in the logs.