### PR TITLE
New deployments of PMD3 will use Stardog 6.2.3.

### DIFF
--- a/package/pmd3-manifest.edn
+++ b/package/pmd3-manifest.edn
@@ -40,6 +40,6 @@
                                        :env #{:dev :ci}}]}
 
               :omni/package-name "drafter-pmd3"
-              :omni/dependencies {"stardog" "5.2.0-2.1" ; pmd3 needs stardog 5. 2.1 includes the log4shell patch.
+              :omni/dependencies {"stardog" "6.2.3-2.1"
                                   "mongodb" "4.4"
                                   "server-ssl" "1.2021"}}]


### PR DESCRIPTION
Goes hand-in-hand with https://github.com/Swirrl/zib/pull/795 and addresses Zib / PMD3 issue https://github.com/Swirrl/zib/issues/794.