### PR TITLE
Improve reloaded/dev workflow with integrant-repl

### DIFF
--- a/drafter/deps.edn
+++ b/drafter/deps.edn
@@ -122,7 +122,8 @@
                               org.clojure/data.json {:mvn/version "2.4.0"}
                               org.clojure/test.check {:mvn/version "1.1.1"}
                               ring-mock/ring-mock {:mvn/version "0.1.5"}
-                              ring/ring-devel {:mvn/version "1.9.4" :exclusions [org.clojure/java.classpath org.clojure/tools.reader]}}}
+                              ring/ring-devel {:mvn/version "1.9.4" :exclusions [org.clojure/java.classpath org.clojure/tools.reader]}
+                              integrant/repl {:mvn/version "0.3.2"}}}
 
            :test {:extra-paths ["env/dev/clj" "test" "test/resources"]}
 

--- a/drafter/src/drafter/main.clj
+++ b/drafter/src/drafter/main.clj
@@ -104,12 +104,6 @@
   (when system
     (ig/halt! system)))
 
-(defn restart-system!
-  "Note this doesn't do a refresh yet."
-  []
-  (stop-system!)
-  (start-system!))
-
 (defn add-shutdown-hook!
   "Register a shutdown hook with the JVM.  This is not guaranteed to
   be called in all circumstances, but should be called upon receipt of


### PR DESCRIPTION
Prior to this change re-evaluating forms at the REPL in many situations wouldn't see those changes deployed into the running system. We introduce the library integrant-repl and it's dependency clojure.tools.namespace to support this.

Developers can now run `(reset)` in the drafter.repl namespace to experience a reloaded workflow more like we do elsewhere.