### PR TITLE
accept query parameter as alternative to header

### DIFF
--- a/drafter/doc/drafter.yml
+++ b/drafter/doc/drafter.yml
@@ -463,6 +463,7 @@ paths:
         - $ref: '#/parameters/graph'
         - $ref: '#/parameters/union-with-live'
         - $ref: '#/parameters/timeout'
+        - $ref: '#/parameters/accept'
       summary: Access the quads inside this Draftset
       description: |
         Request the contents of this draftset in any supported RDF
@@ -569,6 +570,7 @@ paths:
         - $ref: '#/parameters/timeout'
         - $ref: '#/parameters/default-graph-uri'
         - $ref: '#/parameters/named-graph-uri'
+        - $ref: '#/parameters/accept'
 
       tags:
         - Querying
@@ -605,6 +607,7 @@ paths:
         - $ref: '#/parameters/timeout'
         - $ref: '#/parameters/post_default-graph-uri'
         - $ref: '#/parameters/post_named-graph-uri'
+        - $ref: '#/parameters/accept'
       tags:
         - Querying
       responses:
@@ -672,6 +675,7 @@ paths:
         - $ref: '#/parameters/timeout'
         - $ref: '#/parameters/default-graph-uri'
         - $ref: '#/parameters/named-graph-uri'
+        - $ref: '#/parameters/accept'
       tags:
         - SPARQL Endpoints
       responses:
@@ -704,6 +708,7 @@ paths:
         - $ref: '#/parameters/timeout'
         - $ref: '#/parameters/post_default-graph-uri'
         - $ref: '#/parameters/post_named-graph-uri'
+        - $ref: '#/parameters/accept'
       tags:
         - SPARQL Endpoints
       responses:
@@ -1078,6 +1083,12 @@ parameters:
     type: boolean
     allowEmptyValue: true
     default: false
+  accept:
+    name: accept
+    in: query
+    required: false
+    type: string
+    description: Alternative to accept header for clients with no option to set headers
 
 definitions:
   Graph:

--- a/drafter/src/drafter/requests.clj
+++ b/drafter/src/drafter/requests.clj
@@ -1,9 +1,12 @@
 (ns drafter.requests)
 
 (defn accept
-  "Returns the Accept header for a request if one exists."
+  "Returns the accept header or query parameter for a request if either exists.
+   The query parameter has precedence over the header, since it is likely to be
+   used in cases where the user has no control over the header."
   [request]
-  (get-in request [:headers "accept"]))
+  (or (get-in request [:params :accept])
+      (get-in request [:headers "accept"])))
 
 (defn query
   "Returns the query string for a request map"

--- a/drafter/test/drafter/feature/draftset_data/show_test.clj
+++ b/drafter/test/drafter/feature/draftset_data/show_test.clj
@@ -134,3 +134,17 @@
           data-request (tc/with-identity test-editor data-request)
           data-response (handler data-request)]
       (tc/assert-is-not-acceptable-response data-response))))
+
+(tc/deftest-system-with-keys get-draftset-quads-data-with-accept-in-query
+  keys-for-test
+  [{handler [:drafter/routes :draftset/api]} system]
+  (let [draftset (help/create-draftset-through-api handler test-editor)]
+    (help/append-data-to-draftset-through-api
+     handler test-editor draftset "test/resources/test-draftset.trig")
+    (let [accepted "*/*"
+          data-request (help/get-draftset-quads-accept-request
+                        draftset test-editor accepted "false")
+          data-request (assoc-in data-request [:params :accept] "text/csv")
+          data-response (handler data-request)]
+      (tc/assert-is-ok-response data-response)
+      (is (= "text/csv" (get-in data-response [:headers "Content-Type"]))))))

--- a/drafter/test/drafter/rdf/sparql_protocol_test.clj
+++ b/drafter/test/drafter/rdf/sparql_protocol_test.clj
@@ -84,7 +84,18 @@
           response (handler {:uri "/test"
                              :sparql {:prepared-query pquery}
                              :headers {"accept" "text/trig"}})]
-      (tc/assert-is-not-acceptable-response response))))
+      (tc/assert-is-not-acceptable-response response)))
+
+  (testing "Content negotiation via query parameter"
+    (let [handler (sparql-negotiation-handler identity)
+          pquery (prepare-query-str "SELECT * WHERE { ?s ?p ?o }")
+          request {:uri "/sparql"
+                   :sparql {:prepared-query pquery}
+                   :headers {"accept" "*/*"}
+                   :params {:accept "application/json"}}
+          {{:keys [format response-content-type]} :sparql} (handler request)]
+      (is (= "application/json" response-content-type))
+      (is (some? format)))))
 
 (deftest sparql-timeout-handler-test
   (testing "With valid timeout"


### PR DESCRIPTION
Supports specification of media type via an `accept` query parameter, which takes the same values as the `accept` header, but can be used in contexts where the user has no control over headers.

In the original issue there was discussion of using a `format` parameter and mapping back to a media type from there, but I'm not sure there's any advantage to introducing this extra logic over reusing the existing logic for the accept header? Open to be convinced.

e.g.

```
$ curl "localhost:3001/v1/sparql/live?accept=application/json&query=$(urlq 'select (count(*) as ?c) where { ?s ?p ?o }')"
{
  "head" : {
    "vars" : [
      "c"
    ]
  },
  "results" : {
    "bindings" : [
      {
        "c" : {
          "datatype" : "http://www.w3.org/2001/XMLSchema#integer",
          "type" : "literal",
          "value" : "28252"
        }
      }
    ]
  }
}
```

closes #625 