### PR TITLE
Create JAR files for dependent lib directories in skinny task

### DIFF
--- a/drafter/build.clj
+++ b/drafter/build.clj
@@ -61,7 +61,8 @@
     (pack/skinny {:basis basis
                   :path "target/drafter.jar"
                   :path-coerce :jar
-                  :libs "target/lib"})))
+                  :libs "target/lib"
+                  :lib-coerce :jar})))
 
 (defn- copy-files [basis aliases]
   (let [alias-extra-paths (mapcat (fn [alias]


### PR DESCRIPTION
Issue #640 - Skinny jars are usually run with a classpath of 'lib/*:drafter.jar' i.e. the main drafter JAR and all dependent JARs within the lib directory.

The swirrl auth0 dependency is included as a git reference and is not packaged as a jar. This causes it to be written to the lib directory as a directory by default. This directory is not iteself included on the classpath. Writing it and the auth0 resource directories as JAR files result in them being included on the classpath.