### PR TITLE
provide http client session manager to new repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ stardog.log
 drafter/doc/graph_rewriting_fixup.html
 .omni_cache
 .cpcache
+.clj-kondo
+.lsp
+.calva


### PR DESCRIPTION
Exposes the option to pass an HTTP client session manager when constructing a new repository, so that multiple repositories can share a single underlying HTTP client, and benefit from connection pooling / limiting / reuse.

I originally developed this against the `grafter-3` branch, but the relevant options exist in the versions of rdf4j used in master too so I've kept this separate from the grafter 3 work for now.