### PR TITLE
Bump omni stardog deps to 6.2.3-3.0 (java-home config opt)

### DIFF
--- a/dependencies-mongo-auth.edn
+++ b/dependencies-mongo-auth.edn
@@ -1,3 +1,3 @@
-{"stardog" "6.2.3-2.1"
+{"stardog" "6.2.3-3.0"
  "mongodb" "4.4" 
  "server-ssl" "1.2021"}

--- a/dependencies.edn
+++ b/dependencies.edn
@@ -1,3 +1,3 @@
 ;; note you should also edit dependencies-mongo-auth (which is used for the tests) or if you want to install mongo (e.g. for pmd3)
-{"stardog" "6.2.3-2.1" ;; NOTE: also update this in dependencies-mongo-auth.edn
+{"stardog" "6.2.3-3.0" ;; NOTE: also update this in dependencies-mongo-auth.edn
  "server-ssl" "1.2021"}

--- a/package/pmd3-manifest.edn
+++ b/package/pmd3-manifest.edn
@@ -40,6 +40,6 @@
                                        :env #{:dev :ci}}]}
 
               :omni/package-name "drafter-pmd3"
-              :omni/dependencies {"stardog" "6.2.3-2.1"
+              :omni/dependencies {"stardog" "6.2.3-3.0"
                                   "mongodb" "4.4"
                                   "server-ssl" "1.2021"}}]


### PR DESCRIPTION
Need to align the Stardog omni package version in Drafter with the package version in muttnik. Stardog version is now `6.2.3-3.0`, which includes a config option for `JAVA_HOME`. This allows us to run Stardog on JDK 8 in a JDK 17 environment.