### PR TITLE
Closes #654. Support JSON-LD on SPARQL endpoints and RDF API routes

### DIFF
--- a/drafter/doc/drafter.yml
+++ b/drafter/doc/drafter.yml
@@ -485,6 +485,7 @@ paths:
         - application/n-triples
         - application/rdf+xml
         - text/turtle
+        - application/ld+json
       tags:
         - Querying
       responses:
@@ -605,6 +606,7 @@ paths:
         - application/n-triples
         - application/rdf+xml
         - text/turtle
+        - application/ld+json
         - application/sparql-results+xml
         - application/sparql-results+json
         - text/csv
@@ -642,6 +644,7 @@ paths:
         - application/n-triples
         - application/rdf+xml
         - text/turtle
+        - application/ld+json
         - application/sparql-results+xml
         - application/sparql-results+json
         - text/csv
@@ -712,6 +715,7 @@ paths:
         - application/n-triples
         - application/rdf+xml
         - text/turtle
+        - application/ld+json
         - application/sparql-results+xml
         - application/sparql-results+json
         - text/csv
@@ -745,6 +749,7 @@ paths:
         - application/n-triples
         - application/rdf+xml
         - text/turtle
+        - application/ld+json
         - application/sparql-results+xml
         - application/sparql-results+json
         - text/csv

--- a/drafter/src/drafter/rdf/content_negotiation.clj
+++ b/drafter/src/drafter/rdf/content_negotiation.clj
@@ -13,6 +13,7 @@
            RDFFormat/TRIG 0.8
            RDFFormat/TRIX 0.8
            RDFFormat/RDFJSON 0.9
+           RDFFormat/JSONLD 0.9
            csv-rdf-format 0.8
            tsv-rdf-format 0.7}))
 
@@ -21,7 +22,8 @@
           {RDFFormat/NTRIPLES 1.0
            RDFFormat/N3 0.8
            RDFFormat/TURTLE 0.9
-           RDFFormat/RDFXML 0.9})
+           RDFFormat/RDFXML 0.7
+           RDFFormat/JSONLD 0.9})
          {"text/html" [RDFFormat/TURTLE 0.8]}))
 
 (def graph-query-mime-spec


### PR DESCRIPTION
Note: The JSON-LD will not be prettified JSON-LD, it will necessarily be expanded JSON-LD.