### PR TITLE
fix: response values for child jobs use parent job's start-time value

### DIFF
--- a/drafter/src/drafter/feature/draftset_data/common.clj
+++ b/drafter/src/drafter/feature/draftset_data/common.clj
@@ -199,7 +199,9 @@
                 (if-let [result (::result next-state)]
                   (ajobs/job-succeeded! job result)
                   (ajobs/job-succeeded! job))
-                (let [next-job (ajobs/create-child-job job (partial step-job next-state))]
+                (let [next-job (-> job
+                                   (ajobs/child-job-completed!)
+                                   (ajobs/create-child-job (partial step-job next-state)))]
                   (writes/queue-job! next-job)))))]
     (let [initial-state (create-initial-state sm live->draft source)]
       (step-job initial-state job))))


### PR DESCRIPTION
Child jobs used to just overwrite the value for `:start-time` on each step of the state machine.

The fix stores the original start-time under `::parent-job-start-time` and that value is returned as start-time in API responses. Clients shouldn't be aware of child jobs, so this shouldn't break contracts.

Fixes #647