### PR TITLE
Bump pack.alpha; also swap swirrl version for official version

### DIFF
--- a/drafter/deps.edn
+++ b/drafter/deps.edn
@@ -172,7 +172,7 @@
                          :main-opts ["-m" "drafter.main" "/app/config/drafter-auth0.edn"]} 
 
            :build {:deps {io.github.clojure/tools.build {:git/tag "v0.7.5" :git/sha "34727f7"}
-                          io.github.swirrl/pack.alpha {:git/sha "4d835ce4794b103fca5f0c1b5fbdfca903947241"}}
+                          io.github.juxt/pack.alpha {:git/sha "802b3d6347376db51093d122eb4b8cf8a7bbd7cf"}}
                    :ns-default build}
 
            :java9 {:jvm-opts ["--add-modules" "java.xml.bind"]}


### PR DESCRIPTION
This update _should_ fix a an issue which is breaking the build, following a recent Distroless switch to OCI-format manifests.