### PR TITLE
remove wrap-verbs dependency

### DIFF
--- a/drafter/deps.edn
+++ b/drafter/deps.edn
@@ -92,8 +92,6 @@
         ring/ring-core {:mvn/version "1.9.4"}
         ring-cors/ring-cors {:mvn/version "0.1.13"}
 
-        wrap-verbs/wrap-verbs {:mvn/version "0.1.1"}
-
         com.yetanalytics/flint {:mvn/version "0.2.1"
                                 :exclusions [org.clojure/clojure
                                              org.clojure/clojurescript]}

--- a/drafter/src/drafter/handler.clj
+++ b/drafter/src/drafter/handler.clj
@@ -9,7 +9,6 @@
             [ring.middleware.defaults :refer [api-defaults]]
             [ring.middleware.file-info :refer [wrap-file-info]]
             [ring.middleware.resource :refer [wrap-resource]]
-            [ring.middleware.verbs :refer [wrap-verbs]]
             [drafter.errors :refer [wrap-encode-errors]]
             [drafter.logging :refer [log-request]]))
 
@@ -55,7 +54,7 @@
                        (assoc :proxy true))
     ;; add custom middleware here
     :middleware
-    (let [middleware [wrap-verbs
+    (let [middleware [middleware/wrap-verbs
                       wrap-encode-errors
                       middleware/wrap-total-requests-counter
                       middleware/wrap-request-timer


### PR DESCRIPTION
Removing the `wrap-verbs` dependency due to unclear licensing.