### PR TITLE
Bump Stardog to v6.2.6

### DIFF
--- a/dependencies-mongo-auth.edn
+++ b/dependencies-mongo-auth.edn
@@ -1,3 +1,3 @@
-{"stardog" "6.2.3-3.0"
+{"stardog" "6.2.6-3.0"
  "mongodb" "4.4" 
  "server-ssl" "1.2021"}

--- a/dependencies.edn
+++ b/dependencies.edn
@@ -1,3 +1,3 @@
 ;; note you should also edit dependencies-mongo-auth (which is used for the tests) or if you want to install mongo (e.g. for pmd3)
-{"stardog" "6.2.3-3.0" ;; NOTE: also update this in dependencies-mongo-auth.edn
+{"stardog" "6.2.6-3.0" ;; NOTE: also update this in dependencies-mongo-auth.edn
  "server-ssl" "1.2021"}

--- a/drafter/docker-compose.yml
+++ b/drafter/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.10"
 services:
   stardog:
-    image: "europe-west2-docker.pkg.dev/swirrl-devops-infrastructure-1/swirrl/stardog-6.2.3:110"
+    image: "europe-west2-docker.pkg.dev/swirrl-devops-infrastructure-1/swirrl/stardog-6.2.6:160"
     ports:
       - "5820:5820"
     environment:

--- a/package/pmd3-manifest.edn
+++ b/package/pmd3-manifest.edn
@@ -40,6 +40,6 @@
                                        :env #{:dev :ci}}]}
 
               :omni/package-name "drafter-pmd3"
-              :omni/dependencies {"stardog" "6.2.3-3.0"
+              :omni/dependencies {"stardog" "6.2.6-3.0"
                                   "mongodb" "4.4"
                                   "server-ssl" "1.2021"}}]


### PR DESCRIPTION
We are using Stardog v6.2.6 with Zib and PMD3.

From observations of the query planner, we've concluded that the query planner behaves in a more desirable fashion than the planner included in version 6.2.3.