### PR TITLE
Update Stardog dep to 2025 license version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,10 @@
 # See: https://circleci.com/docs/2.0/configuration-reference
 version: 2.1
 
+orbs:
+  aws-cli: circleci/aws-cli@5.1.1
+  aws-s3: circleci/aws-s3@4.1
+
 executors:
   tests-executor:
     docker: # run the steps with Docker
@@ -13,8 +17,7 @@ executors:
         auth:
           username: $DOCKERHUB_USERNAME # can specify string literal values
           password: $DOCKERHUB_PASSWORD # or project environment variable reference
-      - image: "europe-west2-docker.pkg.dev/swirrl-devops-infrastructure-1/swirrl/\
-                stardog-6.2.6:160"
+      - image: "europe-west2-docker.pkg.dev/swirrl-devops-infrastructure-1/swirrl/stardog-6.2.6:195"
         environment:
           CREATE_DATABASE: drafter-test-db
         auth:
@@ -77,6 +80,10 @@ jobs:
     executor: build-executor
     steps:
       - checkout
+      - aws-cli/install
+      - aws-s3/copy:
+          from: s3://swirrl-apps/omni-latest.jar
+          to: omni-latest.jar
       - run:
           name: Package Jars
           command: cd drafter && ./bin/pack
@@ -140,9 +147,13 @@ commands:
   resolve-clj-deps:
     description: "Resolve clj dependencies"
     steps:
+      - aws-cli/install
+      - aws-s3/copy:
+          from: s3://swirrl-apps/omni-latest.jar
+          to: omni-latest.jar
       - run:
           name: Resolve deps
-          command: clojure -P -M:omni
+          command: java -jar omni-latest.jar
 
       - run:
           name: Resolve drafter deps

--- a/dependencies-mongo-auth.edn
+++ b/dependencies-mongo-auth.edn
@@ -1,3 +1,3 @@
-{"stardog" "6.2.6-3.0"
+{"stardog" "6.2.6-4.0"
  "mongodb" "4.4" 
  "server-ssl" "1.2021"}

--- a/dependencies.edn
+++ b/dependencies.edn
@@ -1,3 +1,3 @@
 ;; note you should also edit dependencies-mongo-auth (which is used for the tests) or if you want to install mongo (e.g. for pmd3)
-{"stardog" "6.2.6-3.0" ;; NOTE: also update this in dependencies-mongo-auth.edn
+{"stardog" "6.2.6-4.0" ;; NOTE: also update this in dependencies-mongo-auth.edn
  "server-ssl" "1.2021"}

--- a/drafter/bin/package
+++ b/drafter/bin/package
@@ -49,7 +49,7 @@ popd || exit
 pushd "${REPO_DIR}" || exit
 
 # build packages
-env PACKAGE_VERSION=$PACKAGE_VERSION clojure -M:omni package -m "${TEMP_PACKAGE_DIR}/pmd3-manifest.edn" -o "${TARGET_DIR}"
-env PACKAGE_VERSION=$PACKAGE_VERSION clojure -M:omni package -m "${TEMP_PACKAGE_DIR}/pmd4-manifest.edn" -o "${TARGET_DIR}"
+env PACKAGE_VERSION=$PACKAGE_VERSION java -jar ${REPO_DIR}/omni-latest.jar package -m "${TEMP_PACKAGE_DIR}/pmd3-manifest.edn" -o "${TARGET_DIR}"
+env PACKAGE_VERSION=$PACKAGE_VERSION java -jar ${REPO_DIR}/omni-latest.jar package -m "${TEMP_PACKAGE_DIR}/pmd4-manifest.edn" -o "${TARGET_DIR}"
 
 popd || exit

--- a/drafter/bin/publish-packages
+++ b/drafter/bin/publish-packages
@@ -26,10 +26,10 @@ pushd "${REPO_DIR}" || exit
 
 echo "publishing ${TARGET_DIR}/drafter-pmd3-${PACKAGE_VERSION}.zip"
 
-clojure -M:omni publish -f ${TARGET_DIR}/drafter-pmd3-${PACKAGE_VERSION}.zip
+java -jar ${REPO_DIR}/omni-latest.jar publish -f ${TARGET_DIR}/drafter-pmd3-${PACKAGE_VERSION}.zip
 
 echo "publishing ${TARGET_DIR}/drafter-pmd4-${PACKAGE_VERSION}.zip"
 
-clojure -M:omni publish -f ${TARGET_DIR}/drafter-pmd4-${PACKAGE_VERSION}.zip
+java -jar ${REPO_DIR}/omni-latest.jar publish -f ${TARGET_DIR}/drafter-pmd4-${PACKAGE_VERSION}.zip
 
 popd || exit

--- a/package/pmd3-manifest.edn
+++ b/package/pmd3-manifest.edn
@@ -40,6 +40,6 @@
                                        :env #{:dev :ci}}]}
 
               :omni/package-name "drafter-pmd3"
-              :omni/dependencies {"stardog" "6.2.6-3.0"
+              :omni/dependencies {"stardog" "6.2.6-4.0"
                                   "mongodb" "4.4"
                                   "server-ssl" "1.2021"}}]


### PR DESCRIPTION
Use omni-latest.jar to do omni stuff so that we can get around the annoying SSH github->circle situation, and just use a CircleCI deploy key for this repo.